### PR TITLE
ignores routing as per rid if the value is anti-csrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2021-11-08
+
+### Changes
+-   When routing, ignores `rid` value `"anti-csrf"`: https://github.com/supertokens/supertokens-node/issues/202
+
 ## [0.2.0] - 2021-10-21
 
 ### Breaking changes:

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.2.0"
+const VERSION = "0.2.1"
 
 var (
 	cdiSupported = []string{"2.8", "2.9"}

--- a/supertokens/supertokens.go
+++ b/supertokens/supertokens.go
@@ -162,6 +162,10 @@ func (s *superTokens) middleware(theirHandler http.Handler) http.Handler {
 			return
 		}
 		requestRID := getRIDFromRequest(r)
+		if requestRID == "anti-csrf" {
+			// See https://github.com/supertokens/supertokens-node/issues/202
+			requestRID = ""
+		}
 		if requestRID != "" {
 			var matchedRecipe *RecipeModule
 			for _, recipeModule := range s.RecipeModules {


### PR DESCRIPTION
## Summary of change

Ignores routing based on rid if the value of it is `"anti-csrf"`

## Related issues

-  https://github.com/supertokens/supertokens-node/issues/202

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

No change required

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [x] Tests
