### PR TITLE
Update keyfunc to stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2021-12-06
+- Upgrade `keyfunc` dependency to stable version.
+
 ## [0.3.0] - 2021-11-23
 
 ### Breaking changes:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 // TODO: add go mod tidy in a build process
 
 require (
-	github.com/MicahParks/keyfunc v0.9.0
+	github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/derekstavis/go-qs v0.0.0-20180720192143-9eef69e6c4e7
 	github.com/golang-jwt/jwt/v4 v4.1.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 // TODO: add go mod tidy in a build process
 
 require (
-	github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c
+	github.com/MicahParks/keyfunc v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/derekstavis/go-qs v0.0.0-20180720192143-9eef69e6c4e7
 	github.com/golang-jwt/jwt/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/MicahParks/keyfunc v0.9.0 h1:ada84OuqzwCQLZ/mssYpzzpaAilaIWP45bXzxXmnRuo=
-github.com/MicahParks/keyfunc v0.9.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
-github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c h1:gj6H15VTjg+xISYdRSprR2MA6b/djCoLm1/W/cl1Ly8=
-github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc v1.0.0 h1:O9VAkG6q/LqX4eS+HuIsW9KfC/Luh2NBQr9v4NiwHU0=
+github.com/MicahParks/keyfunc v1.0.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MicahParks/keyfunc v0.9.0 h1:ada84OuqzwCQLZ/mssYpzzpaAilaIWP45bXzxXmnRuo=
 github.com/MicahParks/keyfunc v0.9.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c h1:gj6H15VTjg+xISYdRSprR2MA6b/djCoLm1/W/cl1Ly8=
+github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/recipe/thirdparty/providers/apple.go
+++ b/recipe/thirdparty/providers/apple.go
@@ -180,7 +180,7 @@ func verifyAndGetClaimsAppleIdToken(idToken string, clientId string) (jwt.MapCla
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
 	refreshInterval := time.Hour
 	options := keyfunc.Options{
-		RefreshInterval: &refreshInterval,
+		RefreshInterval: refreshInterval,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/recipe/thirdparty/providers/googleWorkspaces.go
+++ b/recipe/thirdparty/providers/googleWorkspaces.go
@@ -142,7 +142,7 @@ func verifyAndGetClaims(idToken string, clientId string) (jwt.MapClaims, error) 
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
 	refreshInterval := time.Hour
 	options := keyfunc.Options{
-		RefreshInterval: &refreshInterval,
+		RefreshInterval: refreshInterval,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.3.0"
+const VERSION = "0.3.1"
 
 var (
 	cdiSupported = []string{"2.8", "2.9"}


### PR DESCRIPTION
## Summary of change

I've release `v1.0.0` for `github.com/MicahParks/keyfunc` and intend on avoiding `/v2` and beyond. This PR upgrades the dependency to the newly release stable version.

## Related issues

None for this project.

## Test Plan

I ran the existing tests in this repository, but did not contribute tests to this project. 

## Documentation changes

None should be required.

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

Hopefully none.
