### PR TITLE
Fix Error Propagation for echo.labstack

### DIFF
--- a/examples/with-labstack-echo/main.go
+++ b/examples/with-labstack-echo/main.go
@@ -118,7 +118,9 @@ func main() {
 	e.Use(func(hf echo.HandlerFunc) echo.HandlerFunc {
 		return echo.HandlerFunc(func(c echo.Context) error {
 			supertokens.Middleware(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				hf(c)
+				if err := hf(c); err != nil {
+					c.Error(err)
+				}
 			})).ServeHTTP(c.Response(), c.Request())
 			return nil
 		})


### PR DESCRIPTION
Fix error handling propagation

## Summary of change

When testing with my routes, the supertokens Middleware would always return 200, when my route returned 400. Looking through the Echo docs, this is the proper block to use:
```go
				if err := hf(c); err != nil {
					c.Error(err)
				}
```
