### PR TITLE
fix: fixes bug in revokeCode function in the recipeImplementation of passwordless recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.5.9] - 2020-05-10
+### Fixes
 - Fixes bug in the revokeCode function of the recipeimplementation in passwordless recipe 
 
 ## [0.5.8] - 2022-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Fixes bug in the revokeCode function of the recipeimplementation in passwordless recipe 
 
 ## [0.5.8] - 2022-05-05
 ### Added

--- a/recipe/passwordless/recipeFucntions_test.go
+++ b/recipe/passwordless/recipeFucntions_test.go
@@ -1,0 +1,88 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package passwordless
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/passwordless/plessmodels"
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestRevokeCode(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			session.Init(nil),
+			Init(plessmodels.TypeInput{
+				FlowType: "USER_INPUT_CODE_AND_MAGIC_LINK",
+				ContactMethodEmail: plessmodels.ContactMethodEmailConfig{
+					Enabled: true,
+					CreateAndSendCustomEmail: func(email string, userInputCode, urlWithLinkCode *string, codeLifetime uint64, preAuthSessionId string, userContext supertokens.UserContext) error {
+						return nil
+					},
+				},
+			}),
+		},
+	}
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	apiV, err := q.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if unittesting.MaxVersion(apiV, "2.11") == "2.11" {
+		return
+	}
+
+	codeInfo1, err := CreateCodeWithEmail("random@example.com", nil)
+	assert.NoError(t, err)
+	codeInfo2, err := CreateCodeWithEmail("random@example.com", nil)
+	assert.NoError(t, err)
+
+	err = RevokeCode(codeInfo1.OK.CodeID)
+	assert.NoError(t, err)
+
+	result1, err := ConsumeCodeWithUserInputCode(codeInfo1.OK.DeviceID, codeInfo1.OK.UserInputCode, codeInfo1.OK.PreAuthSessionID)
+	assert.NoError(t, err)
+	assert.NotNil(t, result1.RestartFlowError)
+	assert.Nil(t, result1.OK)
+
+	result2, err := ConsumeCodeWithUserInputCode(codeInfo2.OK.DeviceID, codeInfo2.OK.UserInputCode, codeInfo2.OK.PreAuthSessionID)
+	assert.NoError(t, err)
+	assert.Nil(t, result2.RestartFlowError)
+	assert.NotNil(t, result2.OK)
+}

--- a/recipe/passwordless/recipeimplementation.go
+++ b/recipe/passwordless/recipeimplementation.go
@@ -268,7 +268,7 @@ func MakeRecipeImplementation(querier supertokens.Querier) plessmodels.RecipeInt
 		body := map[string]interface{}{
 			"codeId": codeID,
 		}
-		_, err := querier.SendPostRequest("/recipe/signinup/codes/remove", body)
+		_, err := querier.SendPostRequest("/recipe/signinup/code/remove", body)
 		if err != nil {
 			return err
 		}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.5.8"
+const VERSION = "0.5.9"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -100,7 +100,7 @@ func getCurrTimeInMS() uint64 {
 	return uint64(time.Now().UnixNano() / 1000000)
 }
 
-//helper function to execute shell commands
+//helper function to execute shell command
 func shellout(waitFor bool, name string, args ...string) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = getInstallationDir()

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -100,7 +100,7 @@ func getCurrTimeInMS() uint64 {
 	return uint64(time.Now().UnixNano() / 1000000)
 }
 
-//helper function to execute shell command
+//helper function to execute shell commands
 func shellout(waitFor bool, name string, args ...string) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = getInstallationDir()


### PR DESCRIPTION
## Summary of change

Changed the request url to the core of revokeCode funtion in the recipeImplementation of the passwordless recipe 

## Related issues

none

## Test Plan

none

## Documentation changes

none

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

none
