### PR TITLE
feat(go mod tidy workflow): Add github action to enforce go mod tidy in the examples folder

### DIFF
--- a/.github/workflows/enforce-go-mod-tidy.yml
+++ b/.github/workflows/enforce-go-mod-tidy.yml
@@ -7,9 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # When using actions/checkout in a custom container, the directory is not treated as a git repo and does not have a .git directory, therefore we need to initialize it as a git repo. This will allows us to track changes made after go mod tidy runs
-      - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
-      - run: go mod tidy
-      - run: cd examples
-      - run: go mod tidy
-      - run: cd ..
-      - run: git status | grep -q 'nothing to commit, working directory clean' && exit 0 || exit 1
+      - name: Create a new git repository
+        run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
+      - name: Go mod tidy for root project
+        run: go mod tidy
+      - name: Go mod tidy for example apps      
+        working-directory: ./examples
+        run: go mod tidy
+      - name: Check for file changes by go mod tidy
+        run: git status | grep -q 'nothing to commit, working directory clean' && exit 0 || exit 1

--- a/.github/workflows/enforce-go-mod-tidy.yml
+++ b/.github/workflows/enforce-go-mod-tidy.yml
@@ -9,4 +9,6 @@ jobs:
       # When using actions/checkout in a custom container, the directory is not treated as a git repo and does not have a .git directory, therefore we need to initialize it as a git repo. This will allows us to track changes made after go mod tidy runs
       - run: git init && git add --all && git -c user.name='test' -c user.email='test@example.com' commit -m 'init for pr action'
       - run: go mod tidy
+      - run: cd examples
+      - run: go mod tidy
       - run: git status | grep -q 'nothing to commit, working directory clean' && exit 0 || exit 1

--- a/.github/workflows/enforce-go-mod-tidy.yml
+++ b/.github/workflows/enforce-go-mod-tidy.yml
@@ -11,4 +11,5 @@ jobs:
       - run: go mod tidy
       - run: cd examples
       - run: go mod tidy
+      - run: cd ..
       - run: git status | grep -q 'nothing to commit, working directory clean' && exit 0 || exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixes
+- Fixes existing action to run go mod tidy in the examples folder
+
 ## [0.5.9] - 2020-05-10
 ### Fixes
 - Fixes bug in the revokeCode function of the recipeimplementation in passwordless recipe 


### PR DESCRIPTION
## Summary of change

Fixed existing go mod tidy workflow to also work in the examples folder

## Related issues

none

## Test Plan

none

## Documentation changes

none

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

none