### PR TITLE
feat(fixing testingutils): Fixed testing utility function StopST 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fixes existing action to run go mod tidy in the examples folder
+- Fixes stopSt function in testing utils
 
 ## [0.5.9] - 2020-05-10
 ### Fixes

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -120,7 +120,10 @@ func stopST(pid string) {
 			return
 		}
 	}
-	shellout(true, "kill", pid)
+	pid = strings.Trim(pid, "\n")
+	cmd := exec.Command("kill", pid)
+	cmd.Dir = getInstallationDir()
+	cmd.Run()
 	startTime := getCurrTimeInMS()
 	for getCurrTimeInMS()-startTime < 10000 {
 		pidsAfter := getListOfPids()


### PR DESCRIPTION
## Summary of change

Fixed the stopSt function exposed by testing utils fixing breaking tests after core version 3.9

## Related issues

none

## Test Plan

none

## Documentation changes

none

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

none
