### PR TITLE
fix: Secure SMTP implementation

### DIFF
--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -63,6 +63,7 @@ func SendSMTPEmail(config SMTPServiceConfig, content SMTPGetContentResult) error
 		if err != nil {
 			return err
 		}
+		defer c.Quit()
 
 		err = c.Auth(smtpAuth)
 		if err != nil {
@@ -93,7 +94,7 @@ func SendSMTPEmail(config SMTPServiceConfig, content SMTPGetContentResult) error
 			return err
 		}
 
-		return c.Quit()
+		return nil
 	} else {
 		return smtp.SendMail(host+":"+strconv.Itoa(config.Port), smtpAuth, config.From.Email, []string{content.ToEmail}, msg)
 	}

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -1,7 +1,7 @@
 package emaildelivery
 
 import (
-	"errors"
+	"crypto/tls"
 	"net"
 	"net/smtp"
 	"strconv"
@@ -49,54 +49,51 @@ func SendSMTPEmail(config SMTPServiceConfig, content SMTPGetContentResult) error
 	}
 
 	if secure {
-		// TODO: figure out how to send secure emails
-		// tlsconfig := &tls.Config{
-		// 	InsecureSkipVerify: true,
-		// 	ServerName:         host,
-		// }
+		tlsconfig := &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         host,
+		}
 
-		// conn, err := tls.Dial("tcp", servername, tlsconfig)
-		// if err != nil {
-		// 	return err
-		// }
+		conn, err := tls.Dial("tcp", servername, tlsconfig)
+		if err != nil {
+			return err
+		}
 
-		// c, err := smtp.NewClient(conn, host)
-		// if err != nil {
-		// 	return err
-		// }
+		c, err := smtp.NewClient(conn, host)
+		if err != nil {
+			return err
+		}
 
-		// err = c.Auth(smtpAuth)
-		// if err != nil {
-		// 	return err
-		// }
+		err = c.Auth(smtpAuth)
+		if err != nil {
+			return err
+		}
 
-		// if err = c.Mail("From: " + config.From.Name + " <" + config.From.Email + ">"); err != nil {
-		// 	return err
-		// }
+		if err = c.Mail(config.From.Email); err != nil {
+			return err
+		}
 
-		// if err = c.Rcpt(content.ToEmail); err != nil {
-		// 	return err
-		// }
+		if err = c.Rcpt(content.ToEmail); err != nil {
+			return err
+		}
 
-		// // Data
-		// w, err := c.Data()
-		// if err != nil {
-		// 	return err
-		// }
+		// Data
+		w, err := c.Data()
+		if err != nil {
+			return err
+		}
 
-		// _, err = w.Write([]byte(msg))
-		// if err != nil {
-		// 	return err
-		// }
+		_, err = w.Write([]byte(msg))
+		if err != nil {
+			return err
+		}
 
-		// err = w.Close()
-		// if err != nil {
-		// 	return err
-		// }
+		err = w.Close()
+		if err != nil {
+			return err
+		}
 
-		// c.Quit()
-
-		return errors.New("secure connection is not supported")
+		return c.Quit()
 	} else {
 		return smtp.SendMail(host+":"+strconv.Itoa(config.Port), smtpAuth, config.From.Email, []string{content.ToEmail}, msg)
 	}

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -83,6 +83,7 @@ func SendSMTPEmail(config SMTPServiceConfig, content SMTPGetContentResult) error
 		if err != nil {
 			return err
 		}
+		defer w.Close()
 
 		_, err = w.Write([]byte(msg))
 		if err != nil {

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -90,11 +90,6 @@ func SendSMTPEmail(config SMTPServiceConfig, content SMTPGetContentResult) error
 			return err
 		}
 
-		err = w.Close()
-		if err != nil {
-			return err
-		}
-
 		return nil
 	} else {
 		return smtp.SendMail(host+":"+strconv.Itoa(config.Port), smtpAuth, config.From.Email, []string{content.ToEmail}, msg)

--- a/recipe/emailverification/emailverification_email_test.go
+++ b/recipe/emailverification/emailverification_email_test.go
@@ -230,64 +230,64 @@ func TestSMTPServiceOverride(t *testing.T) {
 	assert.Equal(t, sendRawEmailCalled, true)
 }
 
-// func TestSMTPServiceManually(t *testing.T) {
-// 	targetEmail := "..."
-// 	fromEmail := "no-reply@supertokens.com"
-// 	host := "smtp.gmail.com"
-// 	password := "..."
-// 	// secure := false
-// 	// port := 587
-// 	secure := true
-// 	port := 465
+func TestSMTPServiceManually(t *testing.T) {
+	targetEmail := "sattvik@me.com"
+	fromEmail := "sattvik@gmail.com"
+	host := "smtp.gmail.com"
+	password := "lomicmpxczwurcdf"
+	// secure := false
+	// port := 587
+	secure := true
+	port := 465
 
-// 	smtpService := smtpService.MakeSmtpService(emaildelivery.SMTPTypeInput{
-// 		SMTPSettings: emaildelivery.SMTPServiceConfig{
-// 			Host: host,
-// 			From: emaildelivery.SMTPServiceFromConfig{
-// 				Name:  "Test User",
-// 				Email: fromEmail,
-// 			},
-// 			Secure:   &secure,
-// 			Port:     port,
-// 			Password: password,
-// 		},
-// 	})
-// 	configValue := supertokens.TypeInput{
-// 		Supertokens: &supertokens.ConnectionInfo{
-// 			ConnectionURI: "http://localhost:8080",
-// 		},
-// 		AppInfo: supertokens.AppInfo{
-// 			APIDomain:     "api.supertokens.io",
-// 			AppName:       "SuperTokens",
-// 			WebsiteDomain: "supertokens.io",
-// 		},
-// 		RecipeList: []supertokens.Recipe{
-// 			Init(evmodels.TypeInput{
-// 				EmailDelivery: &emaildelivery.TypeInput{
-// 					Service: &smtpService,
-// 				},
-// 				GetEmailForUserID: func(userID string, userContext supertokens.UserContext) (string, error) {
-// 					return targetEmail, nil
-// 				},
-// 			}),
-// 		},
-// 	}
+	smtpService := smtpService.MakeSmtpService(emaildelivery.SMTPTypeInput{
+		SMTPSettings: emaildelivery.SMTPServiceConfig{
+			Host: host,
+			From: emaildelivery.SMTPServiceFromConfig{
+				Name:  "Test User",
+				Email: fromEmail,
+			},
+			Secure:   &secure,
+			Port:     port,
+			Password: password,
+		},
+	})
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(evmodels.TypeInput{
+				EmailDelivery: &emaildelivery.TypeInput{
+					Service: &smtpService,
+				},
+				GetEmailForUserID: func(userID string, userContext supertokens.UserContext) (string, error) {
+					return targetEmail, nil
+				},
+			}),
+		},
+	}
 
-// 	BeforeEach()
-// 	defer AfterEach()
-// 	err := supertokens.Init(configValue)
-// 	if err != nil {
-// 		t.Error(err.Error())
-// 	}
+	BeforeEach()
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
 
-// 	err = (*singletonInstance.EmailDelivery.IngredientInterfaceImpl.SendEmail)(emaildelivery.EmailType{
-// 		EmailVerification: &emaildelivery.EmailVerificationType{
-// 			User: emaildelivery.User{
-// 				ID:    "someId",
-// 				Email: targetEmail,
-// 			},
-// 		},
-// 	}, nil)
+	err = (*singletonInstance.EmailDelivery.IngredientInterfaceImpl.SendEmail)(emaildelivery.EmailType{
+		EmailVerification: &emaildelivery.EmailVerificationType{
+			User: emaildelivery.User{
+				ID:    "someId",
+				Email: targetEmail,
+			},
+		},
+	}, nil)
 
-// 	assert.Nil(t, err)
-// }
+	assert.Nil(t, err)
+}

--- a/recipe/emailverification/emailverification_email_test.go
+++ b/recipe/emailverification/emailverification_email_test.go
@@ -230,64 +230,64 @@ func TestSMTPServiceOverride(t *testing.T) {
 	assert.Equal(t, sendRawEmailCalled, true)
 }
 
-func TestSMTPServiceManually(t *testing.T) {
-	targetEmail := "sattvik@me.com"
-	fromEmail := "sattvik@gmail.com"
-	host := "smtp.gmail.com"
-	password := "lomicmpxczwurcdf"
-	// secure := false
-	// port := 587
-	secure := true
-	port := 465
+// func TestSMTPServiceManually(t *testing.T) {
+// 	targetEmail := "..."
+// 	fromEmail := "no-reply@supertokens.com"
+// 	host := "smtp.gmail.com"
+// 	password := "..."
+// 	// secure := false
+// 	// port := 587
+// 	secure := true
+// 	port := 465
 
-	smtpService := smtpService.MakeSmtpService(emaildelivery.SMTPTypeInput{
-		SMTPSettings: emaildelivery.SMTPServiceConfig{
-			Host: host,
-			From: emaildelivery.SMTPServiceFromConfig{
-				Name:  "Test User",
-				Email: fromEmail,
-			},
-			Secure:   &secure,
-			Port:     port,
-			Password: password,
-		},
-	})
-	configValue := supertokens.TypeInput{
-		Supertokens: &supertokens.ConnectionInfo{
-			ConnectionURI: "http://localhost:8080",
-		},
-		AppInfo: supertokens.AppInfo{
-			APIDomain:     "api.supertokens.io",
-			AppName:       "SuperTokens",
-			WebsiteDomain: "supertokens.io",
-		},
-		RecipeList: []supertokens.Recipe{
-			Init(evmodels.TypeInput{
-				EmailDelivery: &emaildelivery.TypeInput{
-					Service: &smtpService,
-				},
-				GetEmailForUserID: func(userID string, userContext supertokens.UserContext) (string, error) {
-					return targetEmail, nil
-				},
-			}),
-		},
-	}
+// 	smtpService := smtpService.MakeSmtpService(emaildelivery.SMTPTypeInput{
+// 		SMTPSettings: emaildelivery.SMTPServiceConfig{
+// 			Host: host,
+// 			From: emaildelivery.SMTPServiceFromConfig{
+// 				Name:  "Test User",
+// 				Email: fromEmail,
+// 			},
+// 			Secure:   &secure,
+// 			Port:     port,
+// 			Password: password,
+// 		},
+// 	})
+// 	configValue := supertokens.TypeInput{
+// 		Supertokens: &supertokens.ConnectionInfo{
+// 			ConnectionURI: "http://localhost:8080",
+// 		},
+// 		AppInfo: supertokens.AppInfo{
+// 			APIDomain:     "api.supertokens.io",
+// 			AppName:       "SuperTokens",
+// 			WebsiteDomain: "supertokens.io",
+// 		},
+// 		RecipeList: []supertokens.Recipe{
+// 			Init(evmodels.TypeInput{
+// 				EmailDelivery: &emaildelivery.TypeInput{
+// 					Service: &smtpService,
+// 				},
+// 				GetEmailForUserID: func(userID string, userContext supertokens.UserContext) (string, error) {
+// 					return targetEmail, nil
+// 				},
+// 			}),
+// 		},
+// 	}
 
-	BeforeEach()
-	defer AfterEach()
-	err := supertokens.Init(configValue)
-	if err != nil {
-		t.Error(err.Error())
-	}
+// 	BeforeEach()
+// 	defer AfterEach()
+// 	err := supertokens.Init(configValue)
+// 	if err != nil {
+// 		t.Error(err.Error())
+// 	}
 
-	err = (*singletonInstance.EmailDelivery.IngredientInterfaceImpl.SendEmail)(emaildelivery.EmailType{
-		EmailVerification: &emaildelivery.EmailVerificationType{
-			User: emaildelivery.User{
-				ID:    "someId",
-				Email: targetEmail,
-			},
-		},
-	}, nil)
+// 	err = (*singletonInstance.EmailDelivery.IngredientInterfaceImpl.SendEmail)(emaildelivery.EmailType{
+// 		EmailVerification: &emaildelivery.EmailVerificationType{
+// 			User: emaildelivery.User{
+// 				ID:    "someId",
+// 				Email: targetEmail,
+// 			},
+// 		},
+// 	}, nil)
 
-	assert.Nil(t, err)
-}
+// 	assert.Nil(t, err)
+// }


### PR DESCRIPTION
## Summary of change

Golang mail package does not allow `Name <email>` kind of formatting for the from header. We just need to pass the email id directly.

## Related issues

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
