### PR TITLE
feat(fixing typo in thirdparty recipe): fixed a typo in authorizationUrl api func when providers is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixes
+- Fixes the error message in AuthorizationUrlAPI function in the `api` module of the thirdparty recipe in case when providers is nil
+
 ## [0.6.0] - 2022-05-13
 ### Breaking Change
 

--- a/recipe/thirdparty/api/authorisationUrl.go
+++ b/recipe/thirdparty/api/authorisationUrl.go
@@ -36,7 +36,7 @@ func AuthorisationUrlAPI(apiImplementation tpmodels.APIInterface, options tpmode
 	var provider *tpmodels.TypeProvider = findRightProvider(options.Providers, thirdPartyId, nil)
 
 	if provider == nil {
-		return supertokens.BadInputError{Msg: "The third party provider " + thirdPartyId + " seems to not be missing from the backend configs"}
+		return supertokens.BadInputError{Msg: "The third party provider " + thirdPartyId + " seems to be missing from the backend configs."}
 	}
 
 	result, err := (*apiImplementation.AuthorisationUrlGET)(*provider, options, &map[string]interface{}{})

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -72,9 +72,9 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 
 	if provider == nil {
 		if clientId == nil {
-			return supertokens.BadInputError{Msg: "The third party provider " + bodyParams.ThirdPartyId + " seems to not be missing from the backend configs"}
+			return supertokens.BadInputError{Msg: "The third party provider " + bodyParams.ThirdPartyId + " seems to be missing from the backend configs."}
 		} else {
-			return supertokens.BadInputError{Msg: "The third party provider " + bodyParams.ThirdPartyId + " seems to not be missing from the backend configs. If it is configured, then please make sure that you are passing the correct clientId from the frontend."}
+			return supertokens.BadInputError{Msg: "The third party provider " + bodyParams.ThirdPartyId + " seems to be missing from the backend configs. If it is configured, then please make sure that you are passing the correct clientId from the frontend."}
 		}
 	}
 

--- a/recipe/thirdparty/authorisationUrlFeature_test.go
+++ b/recipe/thirdparty/authorisationUrlFeature_test.go
@@ -219,7 +219,7 @@ func TestThirdPartyProviderDoesnotExist(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-	assert.Equal(t, "The third party provider google seems to not be missing from the backend configs", data["message"])
+	assert.Equal(t, "The third party provider google seems to be missing from the backend configs.", data["message"])
 }
 
 func TestInvalidGetParamsForThirdPartyModule(t *testing.T) {

--- a/recipe/thirdparty/signinupFeature_test.go
+++ b/recipe/thirdparty/signinupFeature_test.go
@@ -523,7 +523,7 @@ func TestThirdPartyProviderDoesNotExist(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, "The third party provider google seems to not be missing from the backend configs", response["message"])
+	assert.Equal(t, "The third party provider google seems to be missing from the backend configs.", response["message"])
 }
 
 func TestInvalidPostParamsForThirdPartyModule(t *testing.T) {

--- a/recipe/thirdpartyemailpassword/authorisationUrlFeature_test.go
+++ b/recipe/thirdpartyemailpassword/authorisationUrlFeature_test.go
@@ -154,5 +154,5 @@ func TestThirdPartyProviderDoesnotExsit(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, "The third party provider google seems to not be missing from the backend configs", data["message"].(string))
+	assert.Equal(t, "The third party provider google seems to be missing from the backend configs.", data["message"].(string))
 }


### PR DESCRIPTION
## Summary of change

fixed a typo in authorizationUrl api func when providers is nil

## Related issues

none

## Test Plan

none

## Documentation changes

none

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

none
