### PR TITLE
fix: issue https://github.com/supertokens/supertokens-golang/issues/102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2022-05-17
+### Fixes
+- https://github.com/supertokens/supertokens-golang/issues/102. Sending `preAuthSessionID` instead of `preAuthSessionId` to the core.
+
 ## [0.6.0] - 2022-05-13
 ### Breaking Change
 

--- a/recipe/passwordless/recipeimplementation.go
+++ b/recipe/passwordless/recipeimplementation.go
@@ -234,7 +234,7 @@ func MakeRecipeImplementation(querier supertokens.Querier) plessmodels.RecipeInt
 
 	listCodesByPreAuthSessionID := func(preAuthSessionID string, userContext supertokens.UserContext) (*plessmodels.DeviceType, error) {
 		response, err := querier.SendGetRequest("/recipe/signinup/codes", map[string]string{
-			"preAuthSessionID": preAuthSessionID,
+			"preAuthSessionId": preAuthSessionID,
 		})
 
 		if err != nil {

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.6.0"
+const VERSION = "0.6.1"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}


### PR DESCRIPTION
## Summary of change

Fixes sending `preAuthSessionID` instead of `preAuthSessionId` to the core

## Related issues

-  https://github.com/supertokens/supertokens-golang/issues/102

## Test Plan

-   Added test to generate codes and list them using pre auth session ID

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
