### PR TITLE
fix: fixed custom response writing in API overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2022-05-18
+### Fixes
+- Fixes issue in writing custom response in API Override
+
 ## [0.6.1] - 2022-05-17
 ### Fixes
 - https://github.com/supertokens/supertokens-golang/issues/102. Sending `preAuthSessionID` instead of `preAuthSessionId` to the core.

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/supertokens"
 	"github.com/supertokens/supertokens-golang/test/unittesting"
@@ -132,4 +133,72 @@ func TestUpdateEmailPass(t *testing.T) {
 
 	assert.Equal(t, "OK", data2["status"])
 	assert.Equal(t, email, data2["user"].(map[string]interface{})["email"])
+}
+
+func TestAPICustomResponse(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{
+				Override: &epmodels.OverrideStruct{
+					APIs: func(originalImplementation epmodels.APIInterface) epmodels.APIInterface {
+						oSignUpPost := originalImplementation.SignUpPOST
+						nSignUpPost := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignUpPOSTResponse, error) {
+							options.Res.Header().Set("Content-Type", "application/json; charset=utf-8")
+							options.Res.WriteHeader(201)
+							responseJson := map[string]interface{}{
+								"message": "My custom response",
+							}
+							bytes, _ := json.Marshal(responseJson)
+							options.Res.Write(bytes)
+							return (*oSignUpPost)(formFields, options, userContext)
+						}
+						originalImplementation.SignUpPOST = &nSignUpPost
+						return originalImplementation
+					},
+				},
+			}),
+			session.Init(nil),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.7", cdiVersion) == "2.7" {
+		return
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	res, err := unittesting.SignupRequest("testrandom@gmail.com", "validpass123", testServer.URL)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, 201, res.StatusCode)
+	dataInBytes, err := io.ReadAll(res.Body)
+	data := map[string]interface{}{}
+	json.Unmarshal(dataInBytes, &data)
+	assert.Equal(t, "My custom response", data["message"])
 }

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.6.1"
+const VERSION = "0.6.2"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}

--- a/supertokens/doneWriter.go
+++ b/supertokens/doneWriter.go
@@ -40,6 +40,10 @@ type DoneWriter interface {
 // WrapWriter wraps an http.ResponseWriter, returning a proxy that allows you to
 // hook into various parts of the response process.
 func MakeDoneWriter(w http.ResponseWriter) DoneWriter {
+	if dw, ok := w.(DoneWriter); ok {
+		return dw
+	}
+
 	_, cn := w.(http.CloseNotifier)
 	_, fl := w.(http.Flusher)
 	_, hj := w.(http.Hijacker)


### PR DESCRIPTION
## Summary of change

Check and wrap HttpWriter with DoneWriter only if it is not already wrapped.

## Related issues


## Test Plan
Added Unit test

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
