### PR TITLE
fix: Fixes issue in writing custom response in API override with general error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+## [0.6.4]
+- Fixes issue in writing custom response in API override with general error
 ### Added
 - Adds unit tests to thirdpartypasswordless recipe
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes issue in writing custom response in API override with general error
 ### Added
 - Adds unit tests to thirdpartypasswordless recipe
-  
+
 ## [0.6.3] - 2022-05-19
 ### Fixes
 - Fixes the function signature of the `GetUserByThirdPartyInfo` function in the `thirdpartypasswordless` recipe.

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.6.3"
+const VERSION = "0.6.4"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}

--- a/supertokens/supertokens.go
+++ b/supertokens/supertokens.go
@@ -107,6 +107,10 @@ func supertokensInit(config TypeInput) error {
 }
 
 func defaultOnGeneralError(err error, req *http.Request, res http.ResponseWriter) {
+	w := MakeDoneWriter(res)
+	if w.IsDone() {
+		return
+	}
 	http.Error(res, err.Error(), 500)
 }
 

--- a/supertokens/supertokens.go
+++ b/supertokens/supertokens.go
@@ -286,7 +286,7 @@ func (s *superTokens) errorHandler(originalError error, req *http.Request, res h
 		if catcher := SendNon200Response(res, originalError.Error(), 400); catcher != nil {
 			dw := MakeDoneWriter(res)
 			if !dw.IsDone() {
-				s.OnGeneralError(originalError, req, res)
+				s.OnGeneralError(originalError, req, dw)
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary of change

With custom response, default on general error is outputting extra chars, which should not be done. Have checked for done writer in all the places OnGeneralError is being called. That way, even user overridden OnGeneralError handler won't be called on custom response.

## Related issues


## Test Plan
Have added unit test and also verified the unit test fails without the fix.

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

