### PR TITLE
fix: copying body from request to be able to read again from API override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.5]
+- Fixes issue in reading request body in API override
+
 ## [0.6.4]
 - Fixes issue in writing custom response in API override with general error
 ### Added

--- a/recipe/emailpassword/api/generatePasswordResetToken.go
+++ b/recipe/emailpassword/api/generatePasswordResetToken.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -30,7 +29,7 @@ func GeneratePasswordResetToken(apiImplementation epmodels.APIInterface, options
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/passwordReset.go
+++ b/recipe/emailpassword/api/passwordReset.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
@@ -30,7 +29,7 @@ func PasswordReset(apiImplementation epmodels.APIInterface, options epmodels.API
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/signin.go
+++ b/recipe/emailpassword/api/signin.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -29,7 +28,7 @@ func SignInAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/signup.go
+++ b/recipe/emailpassword/api/signup.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/errors"
@@ -30,7 +29,7 @@ func SignUpAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -19,7 +19,9 @@ package emailpassword
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -270,4 +272,66 @@ func TestAPICustomResponseGeneralError(t *testing.T) {
 	data := map[string]interface{}{}
 	json.Unmarshal(dataInBytes, &data)
 	assert.Equal(t, "My custom response", data["message"])
+}
+
+func TestAPIRequestBodyInAPIOverride(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{
+				Override: &epmodels.OverrideStruct{
+					APIs: func(originalImplementation epmodels.APIInterface) epmodels.APIInterface {
+						oSignUpPost := *originalImplementation.SignUpPOST
+						nSignUpPost := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignUpPOSTResponse, error) {
+							body := options.Req.Body
+							strBody, err := ioutil.ReadAll(body)
+							assert.Nil(t, err)
+							fmt.Println(string(strBody))
+							return oSignUpPost(formFields, options, userContext)
+						}
+						originalImplementation.SignUpPOST = &nSignUpPost
+						return originalImplementation
+					},
+				},
+			}),
+			session.Init(nil),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.7", cdiVersion) == "2.7" {
+		return
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	res, err := unittesting.SignupRequest("testrandom@gmail.com", "validpass123", testServer.URL)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, nil, err)
 }

--- a/recipe/emailverification/api/emailverify.go
+++ b/recipe/emailverification/api/emailverify.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 
@@ -34,7 +33,8 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 			return nil
 		}
 
-		body, err := ioutil.ReadAll(options.Req.Body)
+		body, err := supertokens.ReadFromRequest(options.Req)
+
 		if err != nil {
 			return err
 		}

--- a/recipe/passwordless/api/consumeCode.go
+++ b/recipe/passwordless/api/consumeCode.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/supertokens/supertokens-golang/recipe/passwordless/plessmodels"
@@ -31,7 +30,7 @@ func ConsumeCode(apiImplementation plessmodels.APIInterface, options plessmodels
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/createCode.go
+++ b/recipe/passwordless/api/createCode.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -32,7 +31,7 @@ func CreateCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/resendCode.go
+++ b/recipe/passwordless/api/resendCode.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/supertokens/supertokens-golang/recipe/passwordless/plessmodels"
@@ -30,7 +29,7 @@ func ResendCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -17,7 +17,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -37,7 +36,7 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(options.Req.Body)
+	body, err := supertokens.ReadFromRequest(options.Req)
 	if err != nil {
 		return err
 	}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.6.4"
+const VERSION = "0.6.5"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}

--- a/supertokens/utils.go
+++ b/supertokens/utils.go
@@ -16,8 +16,11 @@
 package supertokens
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -174,4 +177,16 @@ func SendNon200Response(res http.ResponseWriter, message string, statusCode int)
 		}
 	}
 	return nil
+}
+
+func ReadFromRequest(r *http.Request) ([]byte, error) {
+	f := r.Body
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return buf, err
+	}
+
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+
+	return buf, nil
 }


### PR DESCRIPTION
## Summary of change

## Related issues

-   https://github.com/supertokens/supertokens-golang/issues/116

## Test Plan

Added Unit test

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR