### PR TITLE
changes to thirdparty related recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Removed `FIELD_ERROR` status type from third party signinup recipe function.
 - Changes output of `VerifyEmailPOST` to `VerifyEmailPOSTResponse`
 - Changes output of `PasswordResetPOST` to `ResetPasswordPOSTResponse`
+- `SignInUp` recipe function doesn't return `FIELD_ERROR` anymore in thirdparty, thirdpartypasswordless and thirdpartyemailpassword recipe.
+- `SignInUpPOST` api function returns `GENERAL_ERROR` instead of `FIELD_ERROR` in thirdparty, thirdpartypasswordless and thirdpartyemailpassword recipe.
 
 ## [0.6.6]
 - Fixes facebook login

--- a/recipe/thirdparty/api/authorisationUrl.go
+++ b/recipe/thirdparty/api/authorisationUrl.go
@@ -43,8 +43,12 @@ func AuthorisationUrlAPI(apiImplementation tpmodels.APIInterface, options tpmode
 	if err != nil {
 		return err
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{
-		"status": "OK",
-		"url":    result.OK.Url,
-	})
+	if result.OK != nil {
+		return supertokens.Send200Response(options.Res, map[string]interface{}{
+			"status": "OK",
+			"url":    result.OK.Url,
+		})
+	} else {
+		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
+	}
 }

--- a/recipe/thirdparty/api/implementation.go
+++ b/recipe/thirdparty/api/implementation.go
@@ -133,12 +133,7 @@ func MakeAPIImplementation() tpmodels.APIInterface {
 
 		userInfo, err := providerInfo.GetProfileInfo(accessTokenAPIResponse, userContext)
 		if err != nil {
-			errMsg := err.Error()
-			return tpmodels.SignInUpPOSTResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: errMsg,
-				},
-			}, nil
+			return tpmodels.SignInUpPOSTResponse{}, err
 		}
 
 		emailInfo := userInfo.Email
@@ -151,13 +146,6 @@ func MakeAPIImplementation() tpmodels.APIInterface {
 		response, err := (*options.RecipeImplementation.SignInUp)(provider.ID, userInfo.ID, *emailInfo, userContext)
 		if err != nil {
 			return tpmodels.SignInUpPOSTResponse{}, err
-		}
-		if response.FieldError != nil {
-			return tpmodels.SignInUpPOSTResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: response.FieldError.ErrorMsg,
-				},
-			}, nil
 		}
 
 		if emailInfo.IsVerified {

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -94,9 +94,6 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 			"status": "NO_EMAIL_GIVEN_BY_PROVIDER",
 		})
 	} else {
-		return supertokens.Send200Response(options.Res, map[string]interface{}{
-			"status": "FIELD_ERROR",
-			"error":  result.FieldError.ErrorMsg,
-		})
+		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
 }

--- a/recipe/thirdparty/tpmodels/apiInterface.go
+++ b/recipe/thirdparty/tpmodels/apiInterface.go
@@ -31,7 +31,8 @@ type APIInterface struct {
 }
 
 type AuthorisationUrlGETResponse struct {
-	OK *struct{ Url string }
+	OK           *struct{ Url string }
+	GeneralError *supertokens.GeneralErrorResponse
 }
 
 type SignInUpPOSTResponse struct {
@@ -42,7 +43,7 @@ type SignInUpPOSTResponse struct {
 		AuthCodeResponse interface{}
 	}
 	NoEmailGivenByProviderError *struct{}
-	FieldError                  *struct{ ErrorMsg string }
+	GeneralError                *supertokens.GeneralErrorResponse
 }
 
 type APIOptions struct {

--- a/recipe/thirdparty/tpmodels/recipeInterface.go
+++ b/recipe/thirdparty/tpmodels/recipeInterface.go
@@ -29,5 +29,4 @@ type SignInUpResponse struct {
 		CreatedNewUser bool
 		User           User
 	}
-	FieldError *struct{ ErrorMsg string }
 }

--- a/recipe/thirdpartyemailpassword/api/implementation.go
+++ b/recipe/thirdpartyemailpassword/api/implementation.go
@@ -115,11 +115,9 @@ func MakeAPIImplementation() tpepmodels.APIInterface {
 		if err != nil {
 			return tpepmodels.ThirdPartyOutput{}, err
 		}
-		if response.FieldError != nil {
+		if response.GeneralError != nil {
 			return tpepmodels.ThirdPartyOutput{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: response.FieldError.ErrorMsg,
-				},
+				GeneralError: response.GeneralError,
 			}, nil
 		} else if response.NoEmailGivenByProviderError != nil {
 			return tpepmodels.ThirdPartyOutput{

--- a/recipe/thirdpartyemailpassword/api/thirdPartyAPIImplementation.go
+++ b/recipe/thirdpartyemailpassword/api/thirdPartyAPIImplementation.go
@@ -61,9 +61,7 @@ func GetThirdPartyIterfaceImpl(apiImplmentation tpepmodels.APIInterface) tpmodel
 			}, nil
 		} else {
 			return tpmodels.SignInUpPOSTResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
+				GeneralError: result.GeneralError,
 			}, nil
 		}
 	}

--- a/recipe/thirdpartyemailpassword/recipeimplementation/main.go
+++ b/recipe/thirdpartyemailpassword/recipeimplementation/main.go
@@ -99,13 +99,7 @@ func MakeRecipeImplementation(emailPasswordQuerier supertokens.Querier, thirdPar
 		if err != nil {
 			return tpepmodels.SignInUpResponse{}, err
 		}
-		if result.FieldError != nil {
-			return tpepmodels.SignInUpResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
-			}, nil
-		}
+
 		return tpepmodels.SignInUpResponse{
 			OK: &struct {
 				CreatedNewUser bool

--- a/recipe/thirdpartyemailpassword/recipeimplementation/thirdPartyRecipeImplementation.go
+++ b/recipe/thirdpartyemailpassword/recipeimplementation/thirdPartyRecipeImplementation.go
@@ -47,13 +47,6 @@ func MakeThirdPartyRecipeImplementation(recipeImplementation tpepmodels.RecipeIn
 		if err != nil {
 			return tpmodels.SignInUpResponse{}, err
 		}
-		if result.FieldError != nil {
-			return tpmodels.SignInUpResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
-			}, nil
-		}
 
 		return tpmodels.SignInUpResponse{
 			OK: &struct {

--- a/recipe/thirdpartyemailpassword/tpepmodels/apiInterface.go
+++ b/recipe/thirdpartyemailpassword/tpepmodels/apiInterface.go
@@ -57,11 +57,6 @@ type EmailpasswordInput struct {
 	Options    epmodels.APIOptions
 }
 
-type SignInUpAPIOutput struct {
-	EmailpasswordOutput *EmailpasswordOutput
-	ThirdPartyOutput    *ThirdPartyOutput
-}
-
 type EmailpasswordOutput struct {
 	OK *struct {
 		User           User
@@ -79,5 +74,5 @@ type ThirdPartyOutput struct {
 		Session          sessmodels.SessionContainer
 	}
 	NoEmailGivenByProviderError *struct{}
-	FieldError                  *struct{ ErrorMsg string }
+	GeneralError                *supertokens.GeneralErrorResponse
 }

--- a/recipe/thirdpartyemailpassword/tpepmodels/recipeInterface.go
+++ b/recipe/thirdpartyemailpassword/tpepmodels/recipeInterface.go
@@ -37,7 +37,6 @@ type SignInUpResponse struct {
 		CreatedNewUser bool
 		User           User
 	}
-	FieldError *struct{ ErrorMsg string }
 }
 
 type SignUpResponse struct {

--- a/recipe/thirdpartypasswordless/api/implementation.go
+++ b/recipe/thirdpartypasswordless/api/implementation.go
@@ -35,11 +35,9 @@ func MakeAPIImplementation() tplmodels.APIInterface {
 		if err != nil {
 			return tplmodels.ThirdPartySignInUpOutput{}, err
 		}
-		if response.FieldError != nil {
+		if response.GeneralError != nil {
 			return tplmodels.ThirdPartySignInUpOutput{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: response.FieldError.ErrorMsg,
-				},
+				GeneralError: response.GeneralError,
 			}, nil
 		} else if response.NoEmailGivenByProviderError != nil {
 			return tplmodels.ThirdPartySignInUpOutput{

--- a/recipe/thirdpartypasswordless/api/thirdPartyAPIImplementation.go
+++ b/recipe/thirdpartypasswordless/api/thirdPartyAPIImplementation.go
@@ -61,9 +61,7 @@ func GetThirdPartyIterfaceImpl(apiImplmentation tplmodels.APIInterface) tpmodels
 			}, nil
 		} else {
 			return tpmodels.SignInUpPOSTResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
+				GeneralError: result.GeneralError,
 			}, nil
 		}
 	}

--- a/recipe/thirdpartypasswordless/recipeimplementation/main.go
+++ b/recipe/thirdpartypasswordless/recipeimplementation/main.go
@@ -51,13 +51,6 @@ func MakeRecipeImplementation(passwordlessQuerier supertokens.Querier, thirdPart
 		if err != nil {
 			return tplmodels.ThirdPartySignInUp{}, err
 		}
-		if result.FieldError != nil {
-			return tplmodels.ThirdPartySignInUp{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
-			}, nil
-		}
 		return tplmodels.ThirdPartySignInUp{
 			OK: &struct {
 				CreatedNewUser bool

--- a/recipe/thirdpartypasswordless/recipeimplementation/thirdPartyRecipeImplementation.go
+++ b/recipe/thirdpartypasswordless/recipeimplementation/thirdPartyRecipeImplementation.go
@@ -47,13 +47,6 @@ func MakeThirdPartyRecipeImplementation(recipeImplementation tplmodels.RecipeInt
 		if err != nil {
 			return tpmodels.SignInUpResponse{}, err
 		}
-		if result.FieldError != nil {
-			return tpmodels.SignInUpResponse{
-				FieldError: &struct{ ErrorMsg string }{
-					ErrorMsg: result.FieldError.ErrorMsg,
-				},
-			}, nil
-		}
 
 		return tpmodels.SignInUpResponse{
 			OK: &struct {

--- a/recipe/thirdpartypasswordless/signinupFeature_test.go
+++ b/recipe/thirdpartypasswordless/signinupFeature_test.go
@@ -729,11 +729,7 @@ func TestWithThirdPartyPasswordlessErrorThrownFromGetProfileInfoFunction(t *test
 	if err != nil {
 		t.Error(err.Error())
 	}
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	result := *unittesting.HttpResponseToConsumableInformation(resp.Body)
-	assert.Equal(t, "GENERAL_ERROR", result["status"])
-	assert.Equal(t, "error from getProfileInfo", result["message"])
+	assert.Equal(t, 500, resp.StatusCode)
 }
 
 func TestWithThirdPartyPasswordlessInvalidPostParamsForThirdPartyModule(t *testing.T) {

--- a/recipe/thirdpartypasswordless/signinupFeature_test.go
+++ b/recipe/thirdpartypasswordless/signinupFeature_test.go
@@ -732,8 +732,8 @@ func TestWithThirdPartyPasswordlessErrorThrownFromGetProfileInfoFunction(t *test
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	result := *unittesting.HttpResponseToConsumableInformation(resp.Body)
-	assert.Equal(t, "FIELD_ERROR", result["status"])
-	assert.Equal(t, "error from getProfileInfo", result["error"])
+	assert.Equal(t, "GENERAL_ERROR", result["status"])
+	assert.Equal(t, "error from getProfileInfo", result["message"])
 }
 
 func TestWithThirdPartyPasswordlessInvalidPostParamsForThirdPartyModule(t *testing.T) {

--- a/recipe/thirdpartypasswordless/tplmodels/apiInterface.go
+++ b/recipe/thirdpartypasswordless/tplmodels/apiInterface.go
@@ -68,5 +68,5 @@ type ThirdPartySignInUpOutput struct {
 		Session          sessmodels.SessionContainer
 	}
 	NoEmailGivenByProviderError *struct{}
-	FieldError                  *struct{ ErrorMsg string }
+	GeneralError                *supertokens.GeneralErrorResponse
 }

--- a/recipe/thirdpartypasswordless/tplmodels/recipeInterface.go
+++ b/recipe/thirdpartypasswordless/tplmodels/recipeInterface.go
@@ -73,7 +73,6 @@ type ThirdPartySignInUp struct {
 		CreatedNewUser bool
 		User           User
 	}
-	FieldError *struct{ ErrorMsg string }
 }
 
 type SignUpResponse struct {


### PR DESCRIPTION
## Summary of change

- Throws general error from all thirdparty APIs except for apple redirect (that's intentional)
- `SignInUp` recipe function doesn't return `FIELD_ERROR` anymore in thirdparty, thirdpartypasswordless and thirdpartyemailpassword recipe.
- `SignInUpPOST` api function returns `GENERAL_ERROR` instead of `FIELD_ERROR` in thirdparty, thirdpartypasswordless and thirdpartyemailpassword recipe.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/220