### PR TITLE
fix: thirdpartypasswordless email verification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Changes `getEmailForUserIdForEmailVerification` function inside thirdpartypasswordless to take into account passwordless emails and return an empty string in case a passwordless email doesn't exist. This helps situations where the dev wants to customise the email verification functions in the thirdpartypasswordless recipe.
+
 ## [0.6.8] - 2022-06-17
 ### Added
 - `EmailDelivery` user config for Emailpassword, Thirdparty, ThirdpartyEmailpassword, Passwordless and ThirdpartyPasswordless recipes.

--- a/recipe/thirdpartypasswordless/recipe.go
+++ b/recipe/thirdpartypasswordless/recipe.go
@@ -296,10 +296,14 @@ func (r *Recipe) getEmailForUserIdForEmailVerification(userID string, userContex
 		return "", errors.New("Unknown User ID provided")
 	}
 	if userInfo.ThirdParty == nil {
-		// this is a passwordless user.. so we always return some random email,
-		// and in the function for isEmailVerified, we will check if the user
-		// is a passwordless user, and if they are, we will return true in there
-		return "_____supertokens_passwordless_user@supertokens.com", nil
+		if userInfo.Email != nil {
+			return *userInfo.Email, nil
+		}
+		// this is a passwordless user with only a phone number.
+		// returning an empty string here is not a problem since
+		// we override the email verification functions above to
+		// send that the email is already verified for passwordless users.
+		return "", nil
 	}
 	return *userInfo.Email, nil
 }


### PR DESCRIPTION
## Summary of change

Changes `getEmailForUserIdForEmailVerification` in thirdpartypasswordless to take into account passwordless user email as well in case the dev wants to customise the thirdpartypasswordless recipe's email verification functions to take into account passwordless users as well.

## Related issues

-   https://discord.com/channels/603466164219281420/987701400433725440/988016274443489300