### PR TITLE
fix: fixed API responses panic issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+-   Fixes panic while returning empty result object with nil error in the API overrides
 
 ## [0.7.0] - 2022-06-23
 ### Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+## [0.7.1]
 -   Fixes panic while returning empty result object with nil error in the API overrides
 
 ## [0.7.0] - 2022-06-23

--- a/recipe/emailpassword/api/emailExists.go
+++ b/recipe/emailpassword/api/emailExists.go
@@ -38,7 +38,8 @@ func EmailExists(apiImplementation epmodels.APIInterface, options epmodels.APIOp
 			"status": "OK",
 			"exists": result.OK.Exists,
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailpassword/api/emailExists.go
+++ b/recipe/emailpassword/api/emailExists.go
@@ -41,5 +41,6 @@ func EmailExists(apiImplementation epmodels.APIInterface, options epmodels.APIOp
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/emailpassword/api/generatePasswordResetToken.go
+++ b/recipe/emailpassword/api/generatePasswordResetToken.go
@@ -52,7 +52,8 @@ func GeneratePasswordResetToken(apiImplementation epmodels.APIInterface, options
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"status": "OK",
 		})
-	} else {
+	} else if resp.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*resp.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailpassword/api/generatePasswordResetToken.go
+++ b/recipe/emailpassword/api/generatePasswordResetToken.go
@@ -55,5 +55,5 @@ func GeneratePasswordResetToken(apiImplementation epmodels.APIInterface, options
 	} else if resp.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*resp.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/emailpassword/api/passwordReset.go
+++ b/recipe/emailpassword/api/passwordReset.go
@@ -64,7 +64,8 @@ func PasswordReset(apiImplementation epmodels.APIInterface, options epmodels.API
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"status": "RESET_PASSWORD_INVALID_TOKEN_ERROR",
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailpassword/api/passwordReset.go
+++ b/recipe/emailpassword/api/passwordReset.go
@@ -67,5 +67,5 @@ func PasswordReset(apiImplementation epmodels.APIInterface, options epmodels.API
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/emailpassword/api/signin.go
+++ b/recipe/emailpassword/api/signin.go
@@ -56,7 +56,8 @@ func SignInAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 			"status": "OK",
 			"user":   result.OK.User,
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailpassword/api/signin.go
+++ b/recipe/emailpassword/api/signin.go
@@ -59,5 +59,5 @@ func SignInAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/emailpassword/api/signup.go
+++ b/recipe/emailpassword/api/signup.go
@@ -61,7 +61,8 @@ func SignUpAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 				ErrorMsg: "This email already exists. Please sign in instead.",
 			}},
 		}
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailpassword/api/signup.go
+++ b/recipe/emailpassword/api/signup.go
@@ -64,5 +64,5 @@ func SignUpAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -273,6 +273,74 @@ func TestAPICustomResponseGeneralError(t *testing.T) {
 	assert.Equal(t, "My custom response", data["message"])
 }
 
+func TestAPICustomResponseMalformedResult(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{
+				Override: &epmodels.OverrideStruct{
+					APIs: func(originalImplementation epmodels.APIInterface) epmodels.APIInterface {
+						nSignUpPost := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignUpPOSTResponse, error) {
+							options.Res.Header().Set("Content-Type", "application/json; charset=utf-8")
+							options.Res.WriteHeader(201)
+							responseJson := map[string]interface{}{
+								"message": "My custom response",
+							}
+							bytes, _ := json.Marshal(responseJson)
+							options.Res.Write(bytes)
+							return epmodels.SignUpPOSTResponse{}, nil
+						}
+						originalImplementation.SignUpPOST = &nSignUpPost
+						return originalImplementation
+					},
+				},
+			}),
+			session.Init(nil),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.7", cdiVersion) == "2.7" {
+		return
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	res, err := unittesting.SignupRequest("testrandom@gmail.com", "validpass123", testServer.URL)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, 201, res.StatusCode)
+	dataInBytes, err := io.ReadAll(res.Body)
+	assert.Equal(t, nil, err)
+	data := map[string]interface{}{}
+	json.Unmarshal(dataInBytes, &data)
+	assert.Equal(t, "My custom response", data["message"])
+}
+
 func TestAPIRequestBodyInAPIOverride(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{

--- a/recipe/emailverification/api/emailverify.go
+++ b/recipe/emailverification/api/emailverify.go
@@ -66,6 +66,8 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 			}
 		} else if response.GeneralError != nil {
 			result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
+		} else {
+			return supertokens.ErrorIfNoResponse(options.Res)
 		}
 	} else {
 		if apiImplementation.IsEmailVerifiedGET == nil ||
@@ -86,6 +88,8 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 			}
 		} else if isVerified.GeneralError != nil {
 			result = supertokens.ConvertGeneralErrorToJsonResponse(*isVerified.GeneralError)
+		} else {
+			return supertokens.ErrorIfNoResponse(options.Res)
 		}
 	}
 

--- a/recipe/emailverification/api/emailverify.go
+++ b/recipe/emailverification/api/emailverify.go
@@ -64,7 +64,7 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 				"status": "OK",
 				"user":   response.OK.User,
 			}
-		} else {
+		} else if response.GeneralError != nil {
 			result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
 		}
 	} else {
@@ -84,7 +84,7 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 				"status":     "OK",
 				"isVerified": isVerified.OK.IsVerified,
 			}
-		} else {
+		} else if isVerified.GeneralError != nil {
 			result = supertokens.ConvertGeneralErrorToJsonResponse(*isVerified.GeneralError)
 		}
 	}

--- a/recipe/emailverification/api/generateEmailVerifyToken.go
+++ b/recipe/emailverification/api/generateEmailVerifyToken.go
@@ -39,7 +39,8 @@ func GenerateEmailVerifyToken(apiImplementation evmodels.APIInterface, options e
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"status": "OK",
 		})
-	} else {
+	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/emailverification/api/generateEmailVerifyToken.go
+++ b/recipe/emailverification/api/generateEmailVerifyToken.go
@@ -42,5 +42,5 @@ func GenerateEmailVerifyToken(apiImplementation evmodels.APIInterface, options e
 	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/jwt/api/getJWKS.go
+++ b/recipe/jwt/api/getJWKS.go
@@ -39,5 +39,5 @@ func GetJWKS(apiImplementation jwtmodels.APIInterface, options jwtmodels.APIOpti
 	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/jwt/api/getJWKS.go
+++ b/recipe/jwt/api/getJWKS.go
@@ -36,7 +36,8 @@ func GetJWKS(apiImplementation jwtmodels.APIInterface, options jwtmodels.APIOpti
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"keys": response.OK.Keys,
 		})
-	} else {
+	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
+++ b/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
@@ -37,7 +37,8 @@ func GetOpenIdDiscoveryConfiguration(apiImplementation openidmodels.APIInterface
 			"issuer":   response.OK.Issuer,
 			"jwks_uri": response.OK.Jwks_uri,
 		})
-	} else {
+	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
+++ b/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
@@ -40,5 +40,5 @@ func GetOpenIdDiscoveryConfiguration(apiImplementation openidmodels.APIInterface
 	} else if response.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/passwordless/api/consumeCode.go
+++ b/recipe/passwordless/api/consumeCode.go
@@ -118,7 +118,7 @@ func ConsumeCode(apiImplementation plessmodels.APIInterface, options plessmodels
 		result = map[string]interface{}{
 			"status": "RESTART_FLOW_ERROR",
 		}
-	} else {
+	} else if response.GeneralError != nil {
 		result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
 	}
 

--- a/recipe/passwordless/api/consumeCode.go
+++ b/recipe/passwordless/api/consumeCode.go
@@ -120,6 +120,8 @@ func ConsumeCode(apiImplementation plessmodels.APIInterface, options plessmodels
 		}
 	} else if response.GeneralError != nil {
 		result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
+	} else {
+		return supertokens.ErrorIfNoResponse(options.Res)
 	}
 
 	return supertokens.Send200Response(options.Res, result)

--- a/recipe/passwordless/api/createCode.go
+++ b/recipe/passwordless/api/createCode.go
@@ -128,7 +128,7 @@ func CreateCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 			"preAuthSessionId": response.OK.PreAuthSessionID,
 			"flowType":         response.OK.FlowType,
 		}
-	} else {
+	} else if response.GeneralError != nil {
 		result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
 	}
 

--- a/recipe/passwordless/api/createCode.go
+++ b/recipe/passwordless/api/createCode.go
@@ -130,6 +130,8 @@ func CreateCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		}
 	} else if response.GeneralError != nil {
 		result = supertokens.ConvertGeneralErrorToJsonResponse(*response.GeneralError)
+	} else {
+		return supertokens.ErrorIfNoResponse(options.Res)
 	}
 
 	return supertokens.Send200Response(options.Res, result)

--- a/recipe/passwordless/api/doesEmailExist.go
+++ b/recipe/passwordless/api/doesEmailExist.go
@@ -41,5 +41,5 @@ func DoesEmailExist(apiImplementation plessmodels.APIInterface, options plessmod
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/passwordless/api/doesEmailExist.go
+++ b/recipe/passwordless/api/doesEmailExist.go
@@ -38,7 +38,8 @@ func DoesEmailExist(apiImplementation plessmodels.APIInterface, options plessmod
 			"status": "OK",
 			"exists": result.OK.Exists,
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/passwordless/api/doesPhoneNumberExist.go
+++ b/recipe/passwordless/api/doesPhoneNumberExist.go
@@ -41,5 +41,5 @@ func DoesPhoneNumberExist(apiImplementation plessmodels.APIInterface, options pl
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/passwordless/api/doesPhoneNumberExist.go
+++ b/recipe/passwordless/api/doesPhoneNumberExist.go
@@ -38,7 +38,8 @@ func DoesPhoneNumberExist(apiImplementation plessmodels.APIInterface, options pl
 			"status": "OK",
 			"exists": result.OK.Exists,
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/passwordless/api/resendCode.go
+++ b/recipe/passwordless/api/resendCode.go
@@ -78,6 +78,8 @@ func ResendCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 			"status":  "GENERAL_ERROR",
 			"message": response.GeneralError.Message,
 		}
+	} else {
+		return supertokens.ErrorIfNoResponse(options.Res)
 	}
 
 	return supertokens.Send200Response(options.Res, result)

--- a/recipe/passwordless/api/resendCode.go
+++ b/recipe/passwordless/api/resendCode.go
@@ -73,7 +73,7 @@ func ResendCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		result = map[string]interface{}{
 			"status": "RESTART_FLOW_ERROR",
 		}
-	} else {
+	} else if response.GeneralError != nil {
 		result = map[string]interface{}{
 			"status":  "GENERAL_ERROR",
 			"message": response.GeneralError.Message,

--- a/recipe/session/api/signout.go
+++ b/recipe/session/api/signout.go
@@ -37,5 +37,5 @@ func SignOutAPI(apiImplementation sessmodels.APIInterface, options sessmodels.AP
 	} else if resp.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*resp.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/session/api/signout.go
+++ b/recipe/session/api/signout.go
@@ -34,7 +34,8 @@ func SignOutAPI(apiImplementation sessmodels.APIInterface, options sessmodels.AP
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"status": "OK",
 		})
-	} else {
+	} else if resp.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*resp.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/thirdparty/api/authorisationUrl.go
+++ b/recipe/thirdparty/api/authorisationUrl.go
@@ -51,5 +51,5 @@ func AuthorisationUrlAPI(apiImplementation tpmodels.APIInterface, options tpmode
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/thirdparty/api/authorisationUrl.go
+++ b/recipe/thirdparty/api/authorisationUrl.go
@@ -48,7 +48,8 @@ func AuthorisationUrlAPI(apiImplementation tpmodels.APIInterface, options tpmode
 			"status": "OK",
 			"url":    result.OK.Url,
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -96,5 +96,5 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
-	return supertokens.Send200Response(options.Res, map[string]interface{}{})
+	return supertokens.ErrorIfNoResponse(options.Res)
 }

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -93,7 +93,8 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 		return supertokens.Send200Response(options.Res, map[string]interface{}{
 			"status": "NO_EMAIL_GIVEN_BY_PROVIDER",
 		})
-	} else {
+	} else if result.GeneralError != nil {
 		return supertokens.Send200Response(options.Res, supertokens.ConvertGeneralErrorToJsonResponse(*result.GeneralError))
 	}
+	return supertokens.Send200Response(options.Res, map[string]interface{}{})
 }

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.7.0"
+const VERSION = "0.7.1"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13"}

--- a/supertokens/utils.go
+++ b/supertokens/utils.go
@@ -233,3 +233,11 @@ func ConvertGeneralErrorToJsonResponse(resp GeneralErrorResponse) map[string]int
 		"message": resp.Message,
 	}
 }
+
+func ErrorIfNoResponse(res http.ResponseWriter) error {
+	dw := MakeDoneWriter(res)
+	if !dw.IsDone() {
+		return errors.New("invalid return from API interface function")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary of change

Avoids panic when returning mal-formed API response after sending custom response in the API overrides. Checking for nil in the responses before using them.

## Related issues

-   https://github.com/supertokens/supertokens-golang/issues/107

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
