### PR TITLE
feat: Adds request object to default user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Adds:
+
+-   Adds default userContext for API calls that contains the request object. It can be used in APIs / functions override like so:
+
+```golang
+SignIn: func (..., userContext supertokens.UserContext) {
+    if _default, ok := (*userContext)["_default"].(map[string]interface{}); ok {
+        if req, ok := _default["request"].(*http.Request); ok {
+            // do something here with the request object
+        }
+    }
+}
+```
+
 ## [0.7.2] - 2022-06-29
 -   Adds unit tests for resend email & sms services for passwordless and thirdpartypasswordless recipes
 -   Adds User Roles recipe and compatibility with CDI 2.14

--- a/recipe/emailpassword/api/emailExists.go
+++ b/recipe/emailpassword/api/emailExists.go
@@ -29,7 +29,7 @@ func EmailExists(apiImplementation epmodels.APIInterface, options epmodels.APIOp
 	if email == "" {
 		return supertokens.BadInputError{Msg: "Please provide the email as a GET param"}
 	}
-	result, err := (*apiImplementation.EmailExistsGET)(email, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.EmailExistsGET)(email, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/generatePasswordResetToken.go
+++ b/recipe/emailpassword/api/generatePasswordResetToken.go
@@ -44,7 +44,7 @@ func GeneratePasswordResetToken(apiImplementation epmodels.APIInterface, options
 		return err
 	}
 
-	resp, err := (*apiImplementation.GeneratePasswordResetTokenPOST)(formFields, options, &map[string]interface{}{})
+	resp, err := (*apiImplementation.GeneratePasswordResetTokenPOST)(formFields, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/passwordReset.go
+++ b/recipe/emailpassword/api/passwordReset.go
@@ -52,7 +52,7 @@ func PasswordReset(apiImplementation epmodels.APIInterface, options epmodels.API
 		return supertokens.BadInputError{Msg: "The password reset token must be a string"}
 	}
 
-	result, err := (*apiImplementation.PasswordResetPOST)(formFields, token.(string), options, &map[string]interface{}{})
+	result, err := (*apiImplementation.PasswordResetPOST)(formFields, token.(string), options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/signin.go
+++ b/recipe/emailpassword/api/signin.go
@@ -43,7 +43,7 @@ func SignInAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 		return err
 	}
 
-	result, err := (*apiImplementation.SignInPOST)(formFields, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.SignInPOST)(formFields, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/api/signup.go
+++ b/recipe/emailpassword/api/signup.go
@@ -44,7 +44,7 @@ func SignUpAPI(apiImplementation epmodels.APIInterface, options epmodels.APIOpti
 		return err
 	}
 
-	result, err := (*apiImplementation.SignUpPOST)(formFields, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.SignUpPOST)(formFields, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/userContext_test.go
+++ b/recipe/emailpassword/userContext_test.go
@@ -1,0 +1,120 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package emailpassword
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestDefaultUserContext(t *testing.T) {
+	signInContextWorks := false
+	signInAPIContextWorks := false
+	createNewSessionContextWorks := false
+
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{
+				Override: &epmodels.OverrideStruct{
+					Functions: func(originalImplementation epmodels.RecipeInterface) epmodels.RecipeInterface {
+						originalSignIn := *originalImplementation.SignIn
+						newSignIn := func(email string, password string, userContext supertokens.UserContext) (epmodels.SignInResponse, error) {
+							if _default, ok := (*userContext)["_default"].(map[string]interface{}); ok {
+								if _, ok := _default["request"].(*http.Request); ok {
+									signInContextWorks = true
+								}
+							}
+							return originalSignIn(email, password, userContext)
+						}
+						*originalImplementation.SignIn = newSignIn
+						return originalImplementation
+					},
+
+					APIs: func(originalImplementation epmodels.APIInterface) epmodels.APIInterface {
+						originalSignInPOST := *originalImplementation.SignInPOST
+						newSignInPOST := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignInPOSTResponse, error) {
+							if _default, ok := (*userContext)["_default"].(map[string]interface{}); ok {
+								if _, ok := _default["request"].(*http.Request); ok {
+									signInAPIContextWorks = true
+								}
+							}
+							return originalSignInPOST(formFields, options, userContext)
+						}
+						*originalImplementation.SignInPOST = newSignInPOST
+						return originalImplementation
+					},
+				},
+			}),
+			session.Init(&sessmodels.TypeInput{
+				Override: &sessmodels.OverrideStruct{
+					Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+						originalCreateNewSession := *originalImplementation.CreateNewSession
+						newCreateNewSession := func(res http.ResponseWriter, userID string, accessTokenPayload map[string]interface{}, sessionData map[string]interface{}, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+							if _default, ok := (*userContext)["_default"].(map[string]interface{}); ok {
+								if _, ok := _default["request"].(*http.Request); ok {
+									createNewSessionContextWorks = true
+								}
+							}
+							return originalCreateNewSession(res, userID, accessTokenPayload, sessionData, userContext)
+						}
+						*originalImplementation.CreateNewSession = newCreateNewSession
+						return originalImplementation
+					},
+				},
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	unittesting.SignupRequest("random@gmail.com", "validpass123", testServer.URL)
+
+	res1, err := unittesting.SignInRequest("random@gmail.com", "validpass123", testServer.URL)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, 200, res1.StatusCode)
+	assert.True(t, signInContextWorks)
+	assert.True(t, signInAPIContextWorks)
+	assert.True(t, createNewSessionContextWorks)
+}

--- a/recipe/emailverification/api/emailverify.go
+++ b/recipe/emailverification/api/emailverify.go
@@ -51,7 +51,7 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 			return supertokens.BadInputError{Msg: "The email verification token must be a string"}
 		}
 
-		response, err := (*apiImplementation.VerifyEmailPOST)(token.(string), options, &map[string]interface{}{})
+		response, err := (*apiImplementation.VerifyEmailPOST)(token.(string), options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 		if err != nil {
 			return err
 		}

--- a/recipe/emailverification/api/emailverify.go
+++ b/recipe/emailverification/api/emailverify.go
@@ -76,7 +76,7 @@ func EmailVerify(apiImplementation evmodels.APIInterface, options evmodels.APIOp
 			return nil
 		}
 
-		isVerified, err := (*apiImplementation.IsEmailVerifiedGET)(options, &map[string]interface{}{})
+		isVerified, err := (*apiImplementation.IsEmailVerifiedGET)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 		if err != nil {
 			return err
 		}

--- a/recipe/emailverification/api/generateEmailVerifyToken.go
+++ b/recipe/emailverification/api/generateEmailVerifyToken.go
@@ -27,7 +27,7 @@ func GenerateEmailVerifyToken(apiImplementation evmodels.APIInterface, options e
 		return nil
 	}
 
-	response, err := (*apiImplementation.GenerateEmailVerifyTokenPOST)(options, &map[string]interface{}{})
+	response, err := (*apiImplementation.GenerateEmailVerifyTokenPOST)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/jwt/api/getJWKS.go
+++ b/recipe/jwt/api/getJWKS.go
@@ -26,7 +26,7 @@ func GetJWKS(apiImplementation jwtmodels.APIInterface, options jwtmodels.APIOpti
 		return nil
 	}
 
-	response, err := (*apiImplementation.GetJWKSGET)(options, &map[string]interface{}{})
+	response, err := (*apiImplementation.GetJWKSGET)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
+++ b/recipe/openid/api/getOpenIdDiscoveryConfiguration.go
@@ -26,7 +26,7 @@ func GetOpenIdDiscoveryConfiguration(apiImplementation openidmodels.APIInterface
 		return nil
 	}
 
-	response, err := (*apiImplementation.GetOpenIdDiscoveryConfigurationGET)(options, &map[string]interface{}{})
+	response, err := (*apiImplementation.GetOpenIdDiscoveryConfigurationGET)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/consumeCode.go
+++ b/recipe/passwordless/api/consumeCode.go
@@ -89,7 +89,7 @@ func ConsumeCode(apiImplementation plessmodels.APIInterface, options plessmodels
 		linkCodePointer = &t
 	}
 
-	response, err := (*apiImplementation.ConsumeCodePOST)(userInput, linkCodePointer, preAuthSessionID.(string), options, &map[string]interface{}{})
+	response, err := (*apiImplementation.ConsumeCodePOST)(userInput, linkCodePointer, preAuthSessionID.(string), options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/createCode.go
+++ b/recipe/passwordless/api/createCode.go
@@ -114,7 +114,7 @@ func CreateCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		phoneNumberStrPointer = &t
 	}
 
-	response, err := (*apiImplementation.CreateCodePOST)(emailStrPointer, phoneNumberStrPointer, options, &map[string]interface{}{})
+	response, err := (*apiImplementation.CreateCodePOST)(emailStrPointer, phoneNumberStrPointer, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/doesEmailExist.go
+++ b/recipe/passwordless/api/doesEmailExist.go
@@ -29,7 +29,7 @@ func DoesEmailExist(apiImplementation plessmodels.APIInterface, options plessmod
 	if email == "" {
 		return supertokens.BadInputError{Msg: "Please provide the email as a GET param"}
 	}
-	result, err := (*apiImplementation.EmailExistsGET)(email, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.EmailExistsGET)(email, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/doesPhoneNumberExist.go
+++ b/recipe/passwordless/api/doesPhoneNumberExist.go
@@ -29,7 +29,7 @@ func DoesPhoneNumberExist(apiImplementation plessmodels.APIInterface, options pl
 	if phoneNumber == "" {
 		return supertokens.BadInputError{Msg: "Please provide the phoneNumber as a GET param"}
 	}
-	result, err := (*apiImplementation.PhoneNumberExistsGET)(phoneNumber, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.PhoneNumberExistsGET)(phoneNumber, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/api/resendCode.go
+++ b/recipe/passwordless/api/resendCode.go
@@ -58,7 +58,7 @@ func ResendCode(apiImplementation plessmodels.APIInterface, options plessmodels.
 		return supertokens.BadInputError{Msg: "Please make sure that deviceId is a string"}
 	}
 
-	response, err := (*apiImplementation.ResendCodePOST)(deviceID.(string), preAuthSessionID.(string), options, &map[string]interface{}{})
+	response, err := (*apiImplementation.ResendCodePOST)(deviceID.(string), preAuthSessionID.(string), options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/session/api/refresh.go
+++ b/recipe/session/api/refresh.go
@@ -25,7 +25,7 @@ func HandleRefreshAPI(apiImplementation sessmodels.APIInterface, options sessmod
 		options.OtherHandler.ServeHTTP(options.Res, options.Req)
 		return nil
 	}
-	err := (*apiImplementation.RefreshPOST)(options, &map[string]interface{}{})
+	err := (*apiImplementation.RefreshPOST)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/session/api/signout.go
+++ b/recipe/session/api/signout.go
@@ -25,7 +25,7 @@ func SignOutAPI(apiImplementation sessmodels.APIInterface, options sessmodels.AP
 		options.OtherHandler.ServeHTTP(options.Res, options.Req)
 		return nil
 	}
-	resp, err := (*apiImplementation.SignOutPOST)(options, &map[string]interface{}{})
+	resp, err := (*apiImplementation.SignOutPOST)(options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/thirdparty/api/appleRedirect.go
+++ b/recipe/thirdparty/api/appleRedirect.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
 )
 
 func AppleRedirectHandler(apiImplementation tpmodels.APIInterface, options tpmodels.APIOptions) error {
@@ -29,5 +30,5 @@ func AppleRedirectHandler(apiImplementation tpmodels.APIInterface, options tpmod
 	state := options.Req.FormValue("state")
 	code := options.Req.FormValue("code")
 
-	return (*apiImplementation.AppleRedirectHandlerPOST)(code, state, options, &map[string]interface{}{})
+	return (*apiImplementation.AppleRedirectHandlerPOST)(code, state, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 }

--- a/recipe/thirdparty/api/authorisationUrl.go
+++ b/recipe/thirdparty/api/authorisationUrl.go
@@ -39,7 +39,7 @@ func AuthorisationUrlAPI(apiImplementation tpmodels.APIInterface, options tpmode
 		return supertokens.BadInputError{Msg: "The third party provider " + thirdPartyId + " seems to be missing from the backend configs."}
 	}
 
-	result, err := (*apiImplementation.AuthorisationUrlGET)(*provider, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.AuthorisationUrlGET)(*provider, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 	if err != nil {
 		return err
 	}

--- a/recipe/thirdparty/api/signinup.go
+++ b/recipe/thirdparty/api/signinup.go
@@ -77,7 +77,7 @@ func SignInUpAPI(apiImplementation tpmodels.APIInterface, options tpmodels.APIOp
 		}
 	}
 
-	result, err := (*apiImplementation.SignInUpPOST)(*provider, bodyParams.Code, bodyParams.AuthCodeResponse, bodyParams.RedirectURI, options, &map[string]interface{}{})
+	result, err := (*apiImplementation.SignInUpPOST)(*provider, bodyParams.Code, bodyParams.AuthCodeResponse, bodyParams.RedirectURI, options, supertokens.MakeDefaultUserContextFromAPI(options.Req))
 
 	if err != nil {
 		return err

--- a/supertokens/utils.go
+++ b/supertokens/utils.go
@@ -241,3 +241,11 @@ func ErrorIfNoResponse(res http.ResponseWriter) error {
 	}
 	return nil
 }
+
+func MakeDefaultUserContextFromAPI(r *http.Request) UserContext {
+	return &map[string]interface{}{
+		"_default": map[string]interface{}{
+			"request": r,
+		},
+	}
+}


### PR DESCRIPTION
## Summary of change

Adds the request (of type *http.Request) object from the API to the userContext object by default.

## Related issues

## Test Plan
Added unit test

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
