### PR TITLE
test: added test for querier request with UTF-8 data

### DIFF
--- a/recipe/usermetadata/usermetadata_test.go
+++ b/recipe/usermetadata/usermetadata_test.go
@@ -356,3 +356,53 @@ func TestShouldUpdateShallowMerge(t *testing.T) {
 
 	}
 }
+
+func TestGetUserMetadataWithUTF8Encoding(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.13", cdiVersion) == cdiVersion {
+		updatedContent, err := UpdateUserMetadata("userId", map[string]interface{}{
+			"role": "\uFDFD   Æää",
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		assert.Equal(t, updatedContent, map[string]interface{}{
+			"role": "\uFDFD   Æää",
+		})
+
+		metadata, err := GetUserMetadata("userId")
+		if err != nil {
+			t.Error(err.Error())
+		}
+		assert.Equal(t, metadata, map[string]interface{}{
+			"role": "\uFDFD   Æää",
+		})
+	}
+}


### PR DESCRIPTION
## Summary of change

UTF-8 encoding was already part of the header in querier, added test for utf-8 data.

## Related issues

## Test Plan

Also verified that the test fails on removing the header.

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] ~~Changelog has been updated~~
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
