### PR TITLE
fix: Signout clearing cookies issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+-   Clears cookies when RevokeSession is called using the session container, even if the session did not exist from before: https://github.com/supertokens/supertokens-node/issues/343
+
 ## [0.7.2] - 2022-06-29
 -   Adds unit tests for resend email & sms services for passwordless and thirdpartypasswordless recipes
 -   Adds User Roles recipe and compatibility with CDI 2.14

--- a/recipe/session/session.go
+++ b/recipe/session/session.go
@@ -48,14 +48,9 @@ func makeSessionContainerInput(accessToken string, sessionHandle string, userID 
 func newSessionContainer(config sessmodels.TypeNormalisedInput, session *SessionContainerInput) sessmodels.SessionContainer {
 
 	revokeSessionWithContext := func(userContext supertokens.UserContext) error {
-		success, err := (*session.recipeImpl.RevokeSession)(session.sessionHandle, userContext)
-		if err != nil {
-			return err
-		}
-		if success {
-			clearSessionFromCookie(config, session.res)
-		}
-		return nil
+		_, err := (*session.recipeImpl.RevokeSession)(session.sessionHandle, userContext)
+		clearSessionFromCookie(config, session.res)
+		return err
 	}
 
 	getSessionDataWithContext := func(userContext supertokens.UserContext) (map[string]interface{}, error) {

--- a/recipe/session/session.go
+++ b/recipe/session/session.go
@@ -49,8 +49,11 @@ func newSessionContainer(config sessmodels.TypeNormalisedInput, session *Session
 
 	revokeSessionWithContext := func(userContext supertokens.UserContext) error {
 		_, err := (*session.recipeImpl.RevokeSession)(session.sessionHandle, userContext)
+		if err != nil {
+			return err
+		}
 		clearSessionFromCookie(config, session.res)
-		return err
+		return nil
 	}
 
 	getSessionDataWithContext := func(userContext supertokens.UserContext) (map[string]interface{}, error) {

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -190,6 +190,7 @@ func ExtractInfoFromResponse(res *http.Response) map[string]string {
 	var refreshTokenDomain string
 	var refreshTokenHttpOnly = "false"
 	var idRefreshTokenFromCookie string
+	var idRefreshTokenFromHeader string
 	var idRefreshTokenExpiry string
 	var idRefreshTokenDomain string
 	var idRefreshTokenHttpOnly = "false"
@@ -252,20 +253,26 @@ func ExtractInfoFromResponse(res *http.Response) map[string]string {
 			}
 		}
 	}
+	idRefreshTokenFromHeader = res.Header.Get("id-refresh-token")
+	antiCsrfVal := ""
+	if len(antiCsrf) > 0 {
+		antiCsrfVal = antiCsrf[0]
+	}
 	return map[string]string{
-		"antiCsrf":               antiCsrf[0],
-		"sAccessToken":           accessToken,
-		"sRefreshToken":          refreshToken,
-		"sIdRefreshToken":        idRefreshTokenFromCookie,
-		"refreshTokenExpiry":     refreshTokenExpiry,
-		"refreshTokenDomain":     refreshTokenDomain,
-		"refreshTokenHttpOnly":   refreshTokenHttpOnly,
-		"idRefreshTokenExpiry":   idRefreshTokenExpiry,
-		"idRefreshTokenDomain":   idRefreshTokenDomain,
-		"idRefreshTokenHttpOnly": idRefreshTokenHttpOnly,
-		"accessTokenExpiry":      accessTokenExpiry,
-		"accessTokenDomain":      accessTokenDomain,
-		"accessTokenHttpOnly":    accessTokenHttpOnly,
+		"antiCsrf":                 antiCsrfVal,
+		"sAccessToken":             accessToken,
+		"sRefreshToken":            refreshToken,
+		"sIdRefreshToken":          idRefreshTokenFromCookie,
+		"refreshTokenExpiry":       refreshTokenExpiry,
+		"refreshTokenDomain":       refreshTokenDomain,
+		"refreshTokenHttpOnly":     refreshTokenHttpOnly,
+		"idRefreshTokenExpiry":     idRefreshTokenExpiry,
+		"idRefreshTokenFromHeader": idRefreshTokenFromHeader,
+		"idRefreshTokenDomain":     idRefreshTokenDomain,
+		"idRefreshTokenHttpOnly":   idRefreshTokenHttpOnly,
+		"accessTokenExpiry":        accessTokenExpiry,
+		"accessTokenDomain":        accessTokenDomain,
+		"accessTokenHttpOnly":      accessTokenHttpOnly,
 	}
 }
 


### PR DESCRIPTION
## Summary of change
When calling Session.revokeSession, we used to clear the cookies only if the session used to exist in the core. This was an incorrect thing to do cause at the time of API session verification, the session did exist, so we should always clear the cookie when this function is called.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/343

## Test Plan

Added unit test.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
