### PR TITLE
fix: JWKS leaking goroutine issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes:
+- Fixes JWKS Keyfunc call that resulted in a goroutine leak: https://github.com/supertokens/supertokens-golang/issues/155
+
 ## [0.8.1] - 2022-07-12
 
 ### Fixes:

--- a/recipe/thirdparty/providers/apple.go
+++ b/recipe/thirdparty/providers/apple.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/api"
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels"
@@ -177,16 +176,8 @@ func verifyAndGetClaimsAppleIdToken(idToken string, clientId string) (jwt.MapCla
 	// Get the JWKS URL.
 	jwksURL := "https://appleid.apple.com/auth/keys"
 
-	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
-	options := keyfunc.Options{
-		// https://github.com/supertokens/supertokens-golang/issues/155
-		// This causes a leak as the pointer to JWKS would be held in the goroutine and
-		// also results in compounding refresh requests
-		// RefreshInterval: time.Hour,
-	}
-
 	// Create the JWKS from the resource at the given URL.
-	jwks, err := keyfunc.Get(jwksURL, options)
+	jwks, err := getJWKSFromURL(jwksURL)
 	if err != nil {
 		return claims, err
 	}

--- a/recipe/thirdparty/providers/apple.go
+++ b/recipe/thirdparty/providers/apple.go
@@ -178,9 +178,8 @@ func verifyAndGetClaimsAppleIdToken(idToken string, clientId string) (jwt.MapCla
 	jwksURL := "https://appleid.apple.com/auth/keys"
 
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
-	refreshInterval := time.Hour
 	options := keyfunc.Options{
-		RefreshInterval: refreshInterval,
+		// RefreshInterval: time.Hour, // This causes a leak as the pointer to JWKS would be held in the goroutine
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/recipe/thirdparty/providers/apple.go
+++ b/recipe/thirdparty/providers/apple.go
@@ -179,7 +179,10 @@ func verifyAndGetClaimsAppleIdToken(idToken string, clientId string) (jwt.MapCla
 
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
 	options := keyfunc.Options{
-		// RefreshInterval: time.Hour, // This causes a leak as the pointer to JWKS would be held in the goroutine
+		// https://github.com/supertokens/supertokens-golang/issues/155
+		// This causes a leak as the pointer to JWKS would be held in the goroutine and
+		// also results in compounding refresh requests
+		// RefreshInterval: time.Hour,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/recipe/thirdparty/providers/googleWorkspaces.go
+++ b/recipe/thirdparty/providers/googleWorkspaces.go
@@ -18,7 +18,6 @@ package providers
 import (
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
@@ -141,9 +140,8 @@ func verifyAndGetClaims(idToken string, clientId string) (jwt.MapClaims, error) 
 	jwksURL := "https://www.googleapis.com/oauth2/v3/certs"
 
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
-	refreshInterval := time.Hour
 	options := keyfunc.Options{
-		RefreshInterval: refreshInterval,
+		// RefreshInterval: time.Hour, // This causes a leak as the pointer to JWKS would be held in the goroutine
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/recipe/thirdparty/providers/googleWorkspaces.go
+++ b/recipe/thirdparty/providers/googleWorkspaces.go
@@ -141,7 +141,10 @@ func verifyAndGetClaims(idToken string, clientId string) (jwt.MapClaims, error) 
 
 	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
 	options := keyfunc.Options{
-		// RefreshInterval: time.Hour, // This causes a leak as the pointer to JWKS would be held in the goroutine
+		// https://github.com/supertokens/supertokens-golang/issues/155
+		// This causes a leak as the pointer to JWKS would be held in the goroutine and
+		// also results in compounding refresh requests
+		// RefreshInterval: time.Hour,
 	}
 
 	// Create the JWKS from the resource at the given URL.

--- a/recipe/thirdparty/providers/googleWorkspaces.go
+++ b/recipe/thirdparty/providers/googleWorkspaces.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/api"
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels"
@@ -139,16 +138,8 @@ func verifyAndGetClaims(idToken string, clientId string) (jwt.MapClaims, error) 
 	// Get the JWKS URL.
 	jwksURL := "https://www.googleapis.com/oauth2/v3/certs"
 
-	// Create the keyfunc options. Refresh the JWKS every hour and log errors.
-	options := keyfunc.Options{
-		// https://github.com/supertokens/supertokens-golang/issues/155
-		// This causes a leak as the pointer to JWKS would be held in the goroutine and
-		// also results in compounding refresh requests
-		// RefreshInterval: time.Hour,
-	}
-
 	// Create the JWKS from the resource at the given URL.
-	jwks, err := keyfunc.Get(jwksURL, options)
+	jwks, err := getJWKSFromURL(jwksURL)
 	if err != nil {
 		return claims, err
 	}


### PR DESCRIPTION
## Summary of change

Passing refresh interval to the Keyfunc was causing background goroutine to keep the pointer and also ended up compounding refresh requests over time. Caching JWKS using url -> JWKS map and reusing the instance with each call.

## Related issues

-   https://github.com/supertokens/supertokens-golang/issues/155

## Test Plan

Have manually tested that the Apple login works and also ensured the shared instance is getting used for subsequent calls.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

