### PR TITLE
fix: Unit test fix

### DIFF
--- a/frontendDriverInterfaceSupported.json
+++ b/frontendDriverInterfaceSupported.json
@@ -1,7 +1,6 @@
 {
         "_comment": "contains a list of frontend-driver interfaces branch names that this core supports",
         "versions": [
-                "1.14",
                 "1.15"
         ]
 }

--- a/recipe/session/claimsWithJWT_test.go
+++ b/recipe/session/claimsWithJWT_test.go
@@ -57,6 +57,17 @@ func TestJWTShouldCreateRightAccessTokenPayloadWithClaims(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.8", cdiVersion) == "2.8" {
+		return
+	}
 
 	mux := http.NewServeMux()
 	var sessionContainer sessmodels.SessionContainer
@@ -111,6 +122,17 @@ func TestAssertClaimsWithPayloadWithJWTAndCallRightUpdateAccessTokenPayload(t *t
 	err := supertokens.Init(configValue)
 	if err != nil {
 		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.8", cdiVersion) == "2.8" {
+		return
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary of change

Fixed JWT test to run only for cdi >= 2.9
Removed 1.14 from fdi.

## Related issues

## Test Plan

tested with 2.8 and 2.9

## Documentation changes

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
