### PR TITLE
fix: fixed unit test for null dropped in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `UserRoleClaim` and `PermissionClaim` to user roles recipe.
 
 ### Breaking changes
+- Removes support for FDI < 1.15
 - Changed `SignInUp` third party recipe function to accept an email string instead of an object that takes `{ID: string, IsVerified: boolean}`.
 - The frontend SDK should be updated to a version supporting session claims!
   - supertokens-auth-react: >= 0.25.0


### PR DESCRIPTION
## Summary of change

Updated unit test to check based on null being dropped from the core.
Added to changelog - dropped support for FDI 1.14

## Related issues


## Test Plan

tested with new and old

## Documentation changes

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
