### PR TITLE
GoFiber Example: Remove custom net/http response writing

### DIFF
--- a/examples/with-fiber/main.go
+++ b/examples/with-fiber/main.go
@@ -128,7 +128,7 @@ func verifySession(options *sessmodels.VerifySessionOptions) fiber.Handler {
 		}))(c)
 
 		if !sessionVerified {
-			return
+			return &fiber.Error{Message: "unauthorized"}
 		}
 		return c.Next()
 	}


### PR DESCRIPTION
## Summary of change

#### Issue Recap
Heyo 👋🏼 
I have a suggestion for the GoFiber Example Code which also fixes #194. To quickly summarise the issue:
- Through the current implementation shown in the example, the response is already written in the `session.verifySession` callback, which leads to the fact that no error (from verifySession, or from a handlerFunction that sits behind a verifySession middleware) gets carried back to the goFiber instance and to the errorHandler.

Now I tinkered around over the past weeks and I've come to the following realisations:
- I don't see why on this line `supertokens.ErrorHandler` is used, bc at this point verifySession already gave the thumps up and therefore it would only get user created errors. And peaking in on the implementation tells me that it acts only on superTokens created errors and is mainly used to call the custom ErrorHandlers of Recipes which are highly at this point. https://github.com/supertokens/supertokens-golang/blob/e716a17d304b1395a17c04fd3af5c7cf402d6612/examples/with-fiber/main.go#L126-L128
- And all this can be skipped as well if just pass the already prepared response back to goFiber https://github.com/supertokens/supertokens-golang/blob/e716a17d304b1395a17c04fd3af5c7cf402d6612/examples/with-fiber/main.go#L135-L141

#### My Solution

My given suggestion, gives the errors back to the goFiber errorHandler and removes a lot of code, without loosing functionality since the `adaptor.HTTPHandlerFunc` already took care of copying response values written by `session.verifySession` back to the `*fiber.Ctx`.

And its actually crucial that `c.next()` is called outside of the `session.verifySession` callback since only after the callback ran, `adaptor.HTTPHandlerFunc` will copy the httpHeaders back onto the `*fiber.Ctx`. Meaning, if you call `.next()` inside the callback which (down the middleware road) sets for example the content-type header to json. Then `adaptor.HTTPHandlerFunc` will override that content type header with the content headers of the response writer passed to `session.verifySession`

## Test Plan

I tested everything extensively in my local env since I develop with goFiber for a couple of weeks now. I started of with your example implementation and refined it whenever needed
 ![Screenshot 2022-10-19 at 19 14 50](https://user-images.githubusercontent.com/32591853/196759737-5c39e4be-2ea8-4814-95fd-e90b51bad291.png)

## Documentation changes

Not needed afaik

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.