### PR TITLE
fix: fixed apple secret key computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+- Fixes Apple secret key computation
+
 ## [0.9.6] - 2022-10-17
 - Updated google token endpoint
 

--- a/recipe/thirdparty/providers/apple.go
+++ b/recipe/thirdparty/providers/apple.go
@@ -129,11 +129,12 @@ func getClientSecret(clientId, keyId, teamId, privateKey string) (string, error)
 		ExpiresAt: time.Now().Unix() + 86400*180,
 		IssuedAt:  time.Now().Unix(),
 		Audience:  "https://appleid.apple.com",
-		Id:        keyId,
 		Subject:   api.GetActualClientIdFromDevelopmentClientId(clientId),
 		Issuer:    teamId,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["alg"] = "ES256"
+	token.Header["kid"] = keyId
 
 	ecdsaPrivateKey, err := getECDSPrivateKey(privateKey)
 	if err != nil {


### PR DESCRIPTION
## Summary of change

Updated Key claim JWT header before signing.

## Related issues


## Test Plan

Manually tested

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
