### PR TITLE
fix: fiber example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Fixes go fiber to handle handler chaining correctly with verifySession.
 
 ## [0.9.7] - 2022-10-20
 - Updated Frontend integration test server for angular tests

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/supertokens/supertokens-golang v0.0.0-20210909070424-b13c10ce5994
 	github.com/twitchtv/twirp v8.1.0+incompatible
-	github.com/valyala/fasthttp v1.33.0
 	github.com/zeromicro/go-zero v1.3.5
 	google.golang.org/protobuf v1.28.0
 )


### PR DESCRIPTION
## Summary of change

Fixes go fiber example to handle handler chaining correctly with verifySession.

## Related issues

- https://github.com/supertokens/supertokens-golang/issues/194

## Test Plan

Tested that the example works as expected

## Documentation changes


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
