### PR TITLE
fix: added test for jwt mergeIntoAccessTokenPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 - Fixes go fiber to handle handler chaining correctly with verifySession.
+- Added test to check JWT contains updated value when MergeIntoAccessTokenPayload is called.
 
 ## [0.9.7] - 2022-10-20
 - Updated Frontend integration test server for angular tests

--- a/recipe/session/claimsWithJWT_test.go
+++ b/recipe/session/claimsWithJWT_test.go
@@ -231,7 +231,7 @@ func TestMergeIntoAccessTokenPayloadForJWT(t *testing.T) {
 		assert.NotNil(t, sessionContainer)
 
 		sessionContainer.MergeIntoAccessTokenPayload(map[string]interface{}{
-			"lol": "haha",
+			"testClaim": "newValue",
 		})
 		jwtPayloadStr := sessionContainer.GetAccessTokenPayload()["jwt"].(string)
 		jwtPayload := jwt.MapClaims{}
@@ -239,7 +239,7 @@ func TestMergeIntoAccessTokenPayloadForJWT(t *testing.T) {
 		_, _, err = (&jwt.Parser{}).ParseUnverified(jwtPayloadStr, jwtPayload)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "haha", jwtPayload["lol"])
+		assert.Equal(t, "newValue", jwtPayload["testClaim"])
 	}))
 
 	testServer := httptest.NewServer(supertokens.Middleware(mux))


### PR DESCRIPTION
## Summary of change

- Call MergeIntoAccessTokenPayload
- Verify that GetAccessTokenPayload["jwt"] contains the new value.

## Related issues
https://github.com/supertokens/supertokens-node/issues/423

## Test Plan


## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
