### PR TITLE
fix: Adds updating of session claims in email verification token generation API in case the session claims are outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 - Fixes go fiber to handle handler chaining correctly with verifySession.
 - Added test to check JWT contains updated value when MergeIntoAccessTokenPayload is called.
+- Adds updating of session claims in email verification token generation API in case the session claims are outdated.
 
 ## [0.9.7] - 2022-10-20
 - Updated Frontend integration test server for angular tests

--- a/recipe/emailpassword/ev_session_claim_test.go
+++ b/recipe/emailpassword/ev_session_claim_test.go
@@ -1,0 +1,144 @@
+package emailpassword
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/emailverification"
+	"github.com/supertokens/supertokens-golang/recipe/emailverification/evmodels"
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestEVGenerateUpdatesSessionClaims(t *testing.T) {
+	antiCsrfConf := "VIA_TOKEN"
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+			emailverification.Init(evmodels.TypeInput{
+				Mode:                     evmodels.ModeOptional,
+				CreateAndSendCustomEmail: func(user evmodels.User, emailVerificationURLWithToken string, userContext supertokens.UserContext) {},
+			}),
+			session.Init(&sessmodels.TypeInput{
+				AntiCsrf: &antiCsrfConf,
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	resp, err := unittesting.SignupRequest("test@gmail.com", "testPass123", testServer.URL)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 200, resp.StatusCode)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	bodyObj := map[string]interface{}{}
+	err = json.Unmarshal(bodyBytes, &bodyObj)
+	assert.NoError(t, err)
+
+	userId := bodyObj["user"].(map[string]interface{})["id"].(string)
+	infoFromResponse := unittesting.ExtractInfoFromResponse(resp)
+	antiCsrf := infoFromResponse["antiCsrf"]
+
+	token, err := emailverification.CreateEmailVerificationToken(userId, nil)
+	assert.NoError(t, err)
+	_, err = emailverification.VerifyEmailUsingToken(token.OK.Token)
+	assert.NoError(t, err)
+
+	resp, err = unittesting.EmailVerifyTokenRequest(
+		testServer.URL,
+		userId,
+		infoFromResponse["sAccessToken"],
+		infoFromResponse["sIdRefreshToken"],
+		antiCsrf,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	infoFromResponse = unittesting.ExtractInfoFromResponse(resp)
+	b64Bytes, err := base64.StdEncoding.DecodeString(infoFromResponse["frontToken"])
+	assert.NoError(t, err)
+	frontendInfo := map[string]interface{}{}
+	err = json.Unmarshal(b64Bytes, &frontendInfo)
+	assert.NoError(t, err)
+
+	val := frontendInfo["up"].(map[string]interface{})["st-ev"].(map[string]interface{})["v"].(bool)
+	fmt.Println(val)
+	assert.True(t, frontendInfo["up"].(map[string]interface{})["st-ev"].(map[string]interface{})["v"].(bool))
+
+	// Calling again should not modify access token
+	resp, err = unittesting.EmailVerifyTokenRequest(
+		testServer.URL,
+		userId,
+		infoFromResponse["sAccessToken"],
+		infoFromResponse["sIdRefreshToken"],
+		antiCsrf,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	infoFromResponse2 := unittesting.ExtractInfoFromResponse(resp)
+	assert.Empty(t, infoFromResponse2["frontToken"])
+
+	// now we mark the email as unverified and try again
+	emailverification.UnverifyEmail(userId, nil)
+	resp, err = unittesting.EmailVerifyTokenRequest(
+		testServer.URL,
+		userId,
+		infoFromResponse["sAccessToken"],
+		infoFromResponse["sIdRefreshToken"],
+		antiCsrf,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	infoFromResponse = unittesting.ExtractInfoFromResponse(resp)
+	b64Bytes, err = base64.StdEncoding.DecodeString(infoFromResponse["frontToken"])
+	assert.NoError(t, err)
+	frontendInfo = map[string]interface{}{}
+	err = json.Unmarshal(b64Bytes, &frontendInfo)
+	assert.NoError(t, err)
+	assert.False(t, frontendInfo["up"].(map[string]interface{})["st-ev"].(map[string]interface{})["v"].(bool))
+
+	// calling the API again should not modify the access token again
+	resp, err = unittesting.EmailVerifyTokenRequest(
+		testServer.URL,
+		userId,
+		infoFromResponse["sAccessToken"],
+		infoFromResponse["sIdRefreshToken"],
+		antiCsrf,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	infoFromResponse2 = unittesting.ExtractInfoFromResponse(resp)
+	assert.Empty(t, infoFromResponse2["frontToken"])
+}

--- a/recipe/emailverification/api/implementation.go
+++ b/recipe/emailverification/api/implementation.go
@@ -102,10 +102,17 @@ func MakeAPIImplementation() evmodels.APIInterface {
 		}
 
 		if response.EmailAlreadyVerifiedError != nil {
+			if sessionContainer.GetClaimValue(evclaims.EmailVerificationClaim) != true {
+				sessionContainer.FetchAndSetClaimWithContext(evclaims.EmailVerificationClaim, userContext)
+			}
 			supertokens.LogDebugMessage(fmt.Sprintf("Email verification email not sent to %s because it is already verified", email.OK.Email))
 			return evmodels.GenerateEmailVerifyTokenPOSTResponse{
 				EmailAlreadyVerifiedError: &struct{}{},
 			}, nil
+		}
+
+		if sessionContainer.GetClaimValue(evclaims.EmailVerificationClaim) != false {
+			sessionContainer.FetchAndSetClaimWithContext(evclaims.EmailVerificationClaim, userContext)
 		}
 
 		user := evmodels.User{

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -258,6 +258,8 @@ func ExtractInfoFromResponse(res *http.Response) map[string]string {
 	if len(antiCsrf) > 0 {
 		antiCsrfVal = antiCsrf[0]
 	}
+	frontToken := res.Header.Get("front-token")
+
 	return map[string]string{
 		"antiCsrf":                 antiCsrfVal,
 		"sAccessToken":             accessToken,
@@ -273,6 +275,7 @@ func ExtractInfoFromResponse(res *http.Response) map[string]string {
 		"accessTokenExpiry":        accessTokenExpiry,
 		"accessTokenDomain":        accessTokenDomain,
 		"accessTokenHttpOnly":      accessTokenHttpOnly,
+		"frontToken":               frontToken,
 	}
 }
 


### PR DESCRIPTION
…ration API

## Summary of change

Updates session claims related to email verification in email verification token generation API as well - so that if someone is building a custom UI without our SDK on the frontend and they forget to call the get email verification API, then claims will still be updated correctly for them.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/419

## Test Plan

Added test for the specified scenario

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
