### PR TITLE
fix: sendEmail override issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.9.10]
+-   Fixes issue where if SendEmail is overridden with a different email, it will reset that email.
+
 ## [0.9.9] - 2022-11-24
 
 ### Added:

--- a/recipe/emailpassword/emaildelivery/backwardCompatibilityService/main.go
+++ b/recipe/emailpassword/emaildelivery/backwardCompatibilityService/main.go
@@ -34,6 +34,11 @@ func MakeBackwardCompatibilityService(recipeInterfaceImpl epmodels.RecipeInterfa
 			if user == nil {
 				return errors.New("should never come here")
 			}
+
+			// we add this here cause the user may have overridden the sendEmail function
+			// to change the input email and if we don't do this, the input email
+			// will get reset by the getUserById call above.
+			user.Email = input.PasswordReset.User.Email
 			sendResetPasswordEmail(*user, input.PasswordReset.PasswordResetLink, userContext)
 		} else {
 			return errors.New("should never come here")

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.9.9"
+const VERSION = "0.9.10"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"}


### PR DESCRIPTION
## Summary of change

If the user is overriding the sendEmail function in emailpassword recipe to change the input email, their change will not get reflected since our implementation calls the getUserById function which will reset their changed email.

So we reassign the input email to the result of calling getUserById

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
