### PR TITLE
fix: Add username to SMTP settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+-   Adds optional `Username` to `SMTPSettings`, which can be used for SMTP login if username is different from `From.Email`.
 
 ## [0.9.11] - 2022-12-26
 -   Fixes `newPassword` validation in Dashboard API

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -52,7 +52,12 @@ func SendSMTPEmail(settings SMTPSettings, content EmailContent) error {
 		m.SetBody("text/plain", content.Body)
 	}
 
-	d := gomail.NewDialer(settings.Host, settings.Port, settings.From.Email, settings.Password)
+	username := settings.From.Email
+	if settings.Username != nil {
+		username = *settings.Username
+	}
+
+	d := gomail.NewDialer(settings.Host, settings.Port, username, settings.Password)
 
 	if settings.Secure {
 		d.TLSConfig = &tls.Config{InsecureSkipVerify: true, ServerName: settings.Host}

--- a/ingredients/emaildelivery/smtpmodels.go
+++ b/ingredients/emaildelivery/smtpmodels.go
@@ -24,6 +24,7 @@ type SMTPSettings struct {
 	Host     string
 	From     SMTPFrom
 	Port     int
+	Username *string
 	Password string
 	Secure   bool
 }


### PR DESCRIPTION
## Summary of change

Adds optional username to SMTP settings which can be used if username is different from From.Email

## Related issues
- https://github.com/supertokens/supertokens-golang/issues/221

## Test Plan


## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `supertokens/constants.go`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
