### PR TITLE
fix: Update dashboard recipe user Get API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.9.14] - 2022-12-26
+
+-   Fixes an issue in the dashboard recipe when fetching user details for passwordless users that don't have an email associated with their accounts
+-   Updates dashboard version
+-   Updates user GET API for dashboard recipe
+
 ## [0.9.13] - 2022-12-26
 -   Adds optional `Username` to `SMTPSettings`, which can be used for SMTP login if username is different from `From.Email`.
 

--- a/recipe/dashboard/api/userdetails/userGet.go
+++ b/recipe/dashboard/api/userdetails/userGet.go
@@ -51,6 +51,12 @@ func UserGet(apiImplementation dashboardmodels.APIInterface, options dashboardmo
 		}
 	}
 
+	if !api.IsRecipeInitialised(recipeId) {
+		return userGetResponse{
+			Status: "RECIPE_NOT_INITIALISED",
+		}, nil
+	}
+
 	userForRecipeId, _ := api.GetUserForRecipeId(userId, recipeId)
 
 	if userForRecipeId == (dashboardmodels.UserType{}) {

--- a/recipe/dashboard/api/utils.go
+++ b/recipe/dashboard/api/utils.go
@@ -64,8 +64,10 @@ func GetUserForRecipeId(userId string, recipeId string) (user dashboardmodels.Us
 			userToReturn.FirstName = ""
 			userToReturn.LastName = ""
 			userToReturn.Email = response.Email
-			userToReturn.ThirdParty.Id = response.ThirdParty.ID
-			userToReturn.ThirdParty.UserId = response.ThirdParty.UserID
+			userToReturn.ThirdParty = &dashboardmodels.ThirdParty{
+				Id: response.ThirdParty.ID,
+				UserId: response.ThirdParty.UserID,
+			}
 		}
 
 		if userToReturn == (dashboardmodels.UserType{}) {
@@ -77,8 +79,10 @@ func GetUserForRecipeId(userId string, recipeId string) (user dashboardmodels.Us
 				userToReturn.FirstName = ""
 				userToReturn.LastName = ""
 				userToReturn.Email = tpepResponse.Email
-				userToReturn.ThirdParty.Id = tpepResponse.ThirdParty.ID
-				userToReturn.ThirdParty.UserId = tpepResponse.ThirdParty.UserID
+				userToReturn.ThirdParty = &dashboardmodels.ThirdParty{
+					Id: tpepResponse.ThirdParty.ID,
+					UserId: tpepResponse.ThirdParty.UserID,
+				}
 			}
 		}
 	} else if recipeId == passwordless.RECIPE_ID {
@@ -133,9 +137,9 @@ func IsRecipeInitialised(recipeId string) bool {
 		}
 
 		if !isRecipeInitialised {
-			_, tpepErr := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
+			_, err := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
 
-			if tpepErr == nil {
+			if err == nil {
 				isRecipeInitialised = true
 			}
 		}
@@ -147,9 +151,9 @@ func IsRecipeInitialised(recipeId string) bool {
 		}
 
 		if !isRecipeInitialised {
-			_, tppErr := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
+			_, err := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
 
-			if tppErr == nil {
+			if err == nil {
 				isRecipeInitialised = true
 			}
 		}
@@ -161,17 +165,17 @@ func IsRecipeInitialised(recipeId string) bool {
 		}
 
 		if !isRecipeInitialised {
-			_, tpepErr := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
+			_, err := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
 
-			if tpepErr == nil {
+			if err == nil {
 				isRecipeInitialised = true
 			}
 		}
 
 		if !isRecipeInitialised {
-			_, tpepErr := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
+			_, err := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
 
-			if tpepErr == nil {
+			if err == nil {
 				isRecipeInitialised = true
 			}
 		}

--- a/recipe/dashboard/api/utils.go
+++ b/recipe/dashboard/api/utils.go
@@ -124,13 +124,13 @@ func GetUserForRecipeId(userId string, recipeId string) (user dashboardmodels.Us
 
 func IsRecipeInitialised(recipeId string) bool {
 	if recipeId == emailpassword.RECIPE_ID {
-		instance := emailpassword.GetRecipeInstance()
+		_, err := emailpassword.GetRecipeInstanceOrThrowError()
 
-		return instance != nil
+		return err == nil
 	} else if recipeId == passwordless.RECIPE_ID {
-		instance := passwordless.GetRecipeInstance()
+		_, err := passwordless.GetRecipeInstanceOrThrowError()
 
-		return instance != nil
+		return err == nil
 	} else if recipeId == thirdparty.RECIPE_ID {
 		_, err := thirdparty.GetRecipeInstanceOrThrowError()
 

--- a/recipe/dashboard/api/utils.go
+++ b/recipe/dashboard/api/utils.go
@@ -167,6 +167,14 @@ func IsRecipeInitialised(recipeId string) bool {
 				isRecipeInitialised = true
 			}
 		}
+
+		if !isRecipeInitialised {
+			_, tpepErr := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
+
+			if tpepErr == nil {
+				isRecipeInitialised = true
+			}
+		}
 	}
 
 	return isRecipeInitialised

--- a/recipe/dashboard/api/utils.go
+++ b/recipe/dashboard/api/utils.go
@@ -123,19 +123,51 @@ func GetUserForRecipeId(userId string, recipeId string) (user dashboardmodels.Us
 }
 
 func IsRecipeInitialised(recipeId string) bool {
+	isRecipeInitialised := false
+
 	if recipeId == emailpassword.RECIPE_ID {
 		_, err := emailpassword.GetRecipeInstanceOrThrowError()
 
-		return err == nil
+		if err == nil {
+			isRecipeInitialised = true
+		}
+
+		if !isRecipeInitialised {
+			_, tpepErr := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
+
+			if tpepErr == nil {
+				isRecipeInitialised = true
+			}
+		}
 	} else if recipeId == passwordless.RECIPE_ID {
 		_, err := passwordless.GetRecipeInstanceOrThrowError()
 
-		return err == nil
+		if err == nil {
+			isRecipeInitialised = true
+		}
+
+		if !isRecipeInitialised {
+			_, tppErr := thirdpartypasswordless.GetRecipeInstanceOrThrowError()
+
+			if tppErr == nil {
+				isRecipeInitialised = true
+			}
+		}
 	} else if recipeId == thirdparty.RECIPE_ID {
 		_, err := thirdparty.GetRecipeInstanceOrThrowError()
 
-		return err == nil
+		if err == nil {
+			isRecipeInitialised = true
+		}
+
+		if !isRecipeInitialised {
+			_, tpepErr := thirdpartyemailpassword.GetRecipeInstanceOrThrowError()
+
+			if tpepErr == nil {
+				isRecipeInitialised = true
+			}
+		}
 	}
 
-	return false
+	return isRecipeInitialised
 }

--- a/recipe/dashboard/api/utils.go
+++ b/recipe/dashboard/api/utils.go
@@ -121,3 +121,21 @@ func GetUserForRecipeId(userId string, recipeId string) (user dashboardmodels.Us
 
 	return userToReturn, recipeToReturn
 }
+
+func IsRecipeInitialised(recipeId string) bool {
+	if recipeId == emailpassword.RECIPE_ID {
+		instance := emailpassword.GetRecipeInstance()
+
+		return instance != nil
+	} else if recipeId == passwordless.RECIPE_ID {
+		instance := passwordless.GetRecipeInstance()
+
+		return instance != nil
+	} else if recipeId == thirdparty.RECIPE_ID {
+		_, err := thirdparty.GetRecipeInstanceOrThrowError()
+
+		return err == nil
+	}
+
+	return false
+}

--- a/recipe/dashboard/dashboardmodels/models.go
+++ b/recipe/dashboard/dashboardmodels/models.go
@@ -31,8 +31,8 @@ type OverrideStruct struct {
 }
 
 type ThirdParty struct {
-	Id     string `json:"id,omitempty"`
-	UserId string `json:"userId,omitempty"`
+	Id     string `json:"id"`
+	UserId string `json:"userId"`
 }
 
 type UserType struct {
@@ -41,6 +41,6 @@ type UserType struct {
 	FirstName  string     `json:"firstName,omitempty"`
 	LastName   string     `json:"lastName,omitempty"`
 	Email      string     `json:"email,omitempty"`
-	ThirdParty ThirdParty `json:"thirdParty,omitempty"`
+	ThirdParty *ThirdParty `json:"thirdParty,omitempty"`
 	Phone      string     `json:"phoneNumber,omitempty"`
 }

--- a/recipe/dashboard/dashboardmodels/models.go
+++ b/recipe/dashboard/dashboardmodels/models.go
@@ -31,8 +31,8 @@ type OverrideStruct struct {
 }
 
 type ThirdParty struct {
-	Id     string `json:"id"`
-	UserId string `json:"userId"`
+	Id     string `json:"id,omitempty"`
+	UserId string `json:"userId,omitempty"`
 }
 
 type UserType struct {
@@ -42,5 +42,5 @@ type UserType struct {
 	LastName   string     `json:"lastName,omitempty"`
 	Email      string     `json:"email,omitempty"`
 	ThirdParty ThirdParty `json:"thirdParty,omitempty"`
-	Phone      string     `json:"phone,omitempty"`
+	Phone      string     `json:"phoneNumber,omitempty"`
 }

--- a/recipe/emailpassword/config_test.go
+++ b/recipe/emailpassword/config_test.go
@@ -46,7 +46,7 @@ func TestDefaultConfigForEmailPasswordModule(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	singletonEmailPasswordInstance, err := getRecipeInstanceOrThrowError()
+	singletonEmailPasswordInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -106,7 +106,7 @@ func TestChangedConfigForEmailPasswordModule(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	singletonEmailPasswordInstance, err := getRecipeInstanceOrThrowError()
+	singletonEmailPasswordInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -157,7 +157,7 @@ func TestNoEmailPasswordValidatorsGivenShouldAddThem(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	singletonEmailPasswordInstance, err := getRecipeInstanceOrThrowError()
+	singletonEmailPasswordInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -189,7 +189,7 @@ func TestToCheckTheDefaultEmailPasswordValidators(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	singletonEmailPasswordInstance, err := getRecipeInstanceOrThrowError()
+	singletonEmailPasswordInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/recipe/emailpassword/main.go
+++ b/recipe/emailpassword/main.go
@@ -27,7 +27,7 @@ func Init(config *epmodels.TypeInput) supertokens.Recipe {
 }
 
 func SignUpWithContext(email string, password string, userContext supertokens.UserContext) (epmodels.SignUpResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.SignUpResponse{}, err
 	}
@@ -35,7 +35,7 @@ func SignUpWithContext(email string, password string, userContext supertokens.Us
 }
 
 func SignInWithContext(email string, password string, userContext supertokens.UserContext) (epmodels.SignInResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.SignInResponse{}, err
 	}
@@ -43,7 +43,7 @@ func SignInWithContext(email string, password string, userContext supertokens.Us
 }
 
 func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) (*epmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUserByEmailWithContext(email string, userContext supertokens.UserContext) (*epmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func GetUserByEmailWithContext(email string, userContext supertokens.UserContext
 }
 
 func CreateResetPasswordTokenWithContext(userID string, userContext supertokens.UserContext) (epmodels.CreateResetPasswordTokenResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.CreateResetPasswordTokenResponse{}, err
 	}
@@ -67,7 +67,7 @@ func CreateResetPasswordTokenWithContext(userID string, userContext supertokens.
 }
 
 func ResetPasswordUsingTokenWithContext(token string, newPassword string, userContext supertokens.UserContext) (epmodels.ResetPasswordUsingTokenResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.ResetPasswordUsingTokenResponse{}, nil
 	}
@@ -75,7 +75,7 @@ func ResetPasswordUsingTokenWithContext(token string, newPassword string, userCo
 }
 
 func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.UpdateEmailOrPasswordResponse{}, nil
 	}
@@ -83,7 +83,7 @@ func UpdateEmailOrPasswordWithContext(userId string, email *string, password *st
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}

--- a/recipe/emailpassword/recipe.go
+++ b/recipe/emailpassword/recipe.go
@@ -86,7 +86,7 @@ func recipeInit(config *epmodels.TypeInput) supertokens.Recipe {
 	}
 }
 
-func getRecipeInstanceOrThrowError() (*Recipe, error) {
+func GetRecipeInstanceOrThrowError() (*Recipe, error) {
 	if singletonInstance != nil {
 		return singletonInstance, nil
 	}

--- a/recipe/passwordless/config_test.go
+++ b/recipe/passwordless/config_test.go
@@ -77,7 +77,7 @@ func TestMinimumConfigWithEmailOrPhoneContactMethod(t *testing.T) {
 		return
 	}
 
-	passwordlessRecipe, err := getRecipeInstanceOrThrowError()
+	passwordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", passwordlessRecipe.Config.FlowType)
 }
@@ -415,7 +415,7 @@ func TestMinimumConfigWithPhoneContactMethod(t *testing.T) {
 		return
 	}
 
-	passwordlessRecipe, err := getRecipeInstanceOrThrowError()
+	passwordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", passwordlessRecipe.Config.FlowType)
 	assert.True(t, passwordlessRecipe.Config.ContactMethodPhone.Enabled)
@@ -942,7 +942,7 @@ func TestMinimumConfigWithEmailContactMethod(t *testing.T) {
 		return
 	}
 
-	passwordlessRecipe, err := getRecipeInstanceOrThrowError()
+	passwordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", passwordlessRecipe.Config.FlowType)
 	assert.True(t, passwordlessRecipe.Config.ContactMethodEmail.Enabled)

--- a/recipe/passwordless/main.go
+++ b/recipe/passwordless/main.go
@@ -30,7 +30,7 @@ func Init(config plessmodels.TypeInput) supertokens.Recipe {
 }
 
 func CreateCodeWithEmailWithContext(email string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.CreateCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.CreateCodeResponse{}, err
 	}
@@ -41,7 +41,7 @@ func CreateCodeWithEmailWithContext(email string, userInputCode *string, userCon
 }
 
 func CreateCodeWithPhoneNumberWithContext(phoneNumber string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.CreateCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.CreateCodeResponse{}, err
 	}
@@ -52,7 +52,7 @@ func CreateCodeWithPhoneNumberWithContext(phoneNumber string, userInputCode *str
 }
 
 func CreateNewCodeForDeviceWithContext(deviceID string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.ResendCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.ResendCodeResponse{}, err
 	}
@@ -63,7 +63,7 @@ func CreateNewCodeForDeviceWithContext(deviceID string, userInputCode *string, u
 }
 
 func ConsumeCodeWithUserInputCodeWithContext(deviceID string, userInputCode string, preAuthSessionID string, userContext supertokens.UserContext) (plessmodels.ConsumeCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.ConsumeCodeResponse{}, err
 	}
@@ -77,7 +77,7 @@ func ConsumeCodeWithUserInputCodeWithContext(deviceID string, userInputCode stri
 }
 
 func ConsumeCodeWithLinkCodeWithContext(linkCode string, preAuthSessionID string, userContext supertokens.UserContext) (plessmodels.ConsumeCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.ConsumeCodeResponse{}, err
 	}
@@ -88,7 +88,7 @@ func ConsumeCodeWithLinkCodeWithContext(linkCode string, preAuthSessionID string
 }
 
 func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) (*plessmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUserByEmailWithContext(email string, userContext supertokens.UserContext) (*plessmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func GetUserByEmailWithContext(email string, userContext supertokens.UserContext
 }
 
 func GetUserByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) (*plessmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func GetUserByPhoneNumberWithContext(phoneNumber string, userContext supertokens
 }
 
 func UpdateUserWithContext(userID string, email *string, phoneNumber *string, userContext supertokens.UserContext) (plessmodels.UpdateUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.UpdateUserResponse{}, err
 	}
@@ -132,7 +132,7 @@ func UpdateUserWithContext(userID string, email *string, phoneNumber *string, us
 }
 
 func RevokeAllCodesByEmailWithContext(email string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func RevokeAllCodesByEmailWithContext(email string, userContext supertokens.User
 }
 
 func RevokeAllCodesByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func RevokeAllCodesByPhoneNumberWithContext(phoneNumber string, userContext supe
 }
 
 func RevokeCodeWithContext(codeID string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func RevokeCodeWithContext(codeID string, userContext supertokens.UserContext) e
 }
 
 func ListCodesByEmailWithContext(email string, userContext supertokens.UserContext) ([]plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return []plessmodels.DeviceType{}, err
 	}
@@ -176,7 +176,7 @@ func ListCodesByEmailWithContext(email string, userContext supertokens.UserConte
 }
 
 func ListCodesByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) ([]plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return []plessmodels.DeviceType{}, err
 	}
@@ -187,7 +187,7 @@ func ListCodesByPhoneNumberWithContext(phoneNumber string, userContext supertoke
 }
 
 func ListCodesByDeviceIDWithContext(deviceID string, userContext supertokens.UserContext) (*plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func ListCodesByDeviceIDWithContext(deviceID string, userContext supertokens.Use
 }
 
 func ListCodesByPreAuthSessionIDWithContext(preAuthSessionID string, userContext supertokens.UserContext) (*plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func ListCodesByPreAuthSessionIDWithContext(preAuthSessionID string, userContext
 }
 
 func CreateMagicLinkByEmailWithContext(email string, userContext supertokens.UserContext) (string, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return "", err
 	}
@@ -220,7 +220,7 @@ func CreateMagicLinkByEmailWithContext(email string, userContext supertokens.Use
 }
 
 func CreateMagicLinkByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) (string, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return "", err
 	}
@@ -235,7 +235,7 @@ func SignInUpByEmailWithContext(email string, userContext supertokens.UserContex
 	CreatedNewUser   bool
 	User             plessmodels.User
 }, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return struct {
 			PreAuthSessionID string
@@ -254,7 +254,7 @@ func SignInUpByPhoneNumberWithContext(phoneNumber string, userContext supertoken
 	CreatedNewUser   bool
 	User             plessmodels.User
 }, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return struct {
 			PreAuthSessionID string
@@ -269,7 +269,7 @@ func SignInUpByPhoneNumberWithContext(phoneNumber string, userContext supertoken
 }
 
 func DeleteEmailForUserWithContext(userID string, userContext supertokens.UserContext) (plessmodels.DeleteUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.DeleteUserResponse{}, err
 	}
@@ -280,7 +280,7 @@ func DeleteEmailForUserWithContext(userID string, userContext supertokens.UserCo
 }
 
 func DeletePhoneNumberForUserWithContext(userID string, userContext supertokens.UserContext) (plessmodels.DeleteUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.DeleteUserResponse{}, err
 	}
@@ -291,7 +291,7 @@ func DeletePhoneNumberForUserWithContext(userID string, userContext supertokens.
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens
 }
 
 func SendSmsWithContext(input smsdelivery.SmsType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}

--- a/recipe/passwordless/recipe.go
+++ b/recipe/passwordless/recipe.go
@@ -82,7 +82,7 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config p
 	return *r, nil
 }
 
-func getRecipeInstanceOrThrowError() (*Recipe, error) {
+func GetRecipeInstanceOrThrowError() (*Recipe, error) {
 	if singletonInstance != nil {
 		return singletonInstance, nil
 	}

--- a/recipe/thirdparty/main.go
+++ b/recipe/thirdparty/main.go
@@ -31,7 +31,7 @@ func Init(config *tpmodels.TypeInput) supertokens.Recipe {
 }
 
 func SignInUpWithContext(thirdPartyID string, thirdPartyUserID string, email string, userContext supertokens.UserContext) (tpmodels.SignInUpResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tpmodels.SignInUpResponse{}, err
 	}
@@ -39,7 +39,7 @@ func SignInUpWithContext(thirdPartyID string, thirdPartyUserID string, email str
 }
 
 func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) (*tpmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUsersByEmailWithContext(email string, userContext supertokens.UserContext) ([]tpmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return []tpmodels.User{}, err
 	}
@@ -55,7 +55,7 @@ func GetUsersByEmailWithContext(email string, userContext supertokens.UserContex
 }
 
 func GetUserByThirdPartyInfoWithContext(thirdPartyID, thirdPartyUserID string, userContext supertokens.UserContext) (*tpmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}

--- a/recipe/thirdparty/provider_test.go
+++ b/recipe/thirdparty/provider_test.go
@@ -60,7 +60,7 @@ func TestMinimumConfigForGoogleAsThirdPartyProvider(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -130,7 +130,7 @@ func TestPassingAdditionalParamsInAuthUrlForGoogleAndCheckItsPresense(t *testing
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -199,7 +199,7 @@ func TestPassingScopesInConfigForGoogle(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -263,7 +263,7 @@ func TestMinimumConfigForFacebookAsThirdPartyProvider(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -327,7 +327,7 @@ func TestPassingScopesInConfigForFacebook(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -380,7 +380,7 @@ func TestMinimumConfigForGithubAsThirdPartyProvider(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -446,7 +446,7 @@ func TestPassingAdditionalParamsInAuthUrlForGithubAndCheckItsPresense(t *testing
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -503,7 +503,7 @@ func TestPassingScopesInConfigForGithub(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	singletonInstance, err := getRecipeInstanceOrThrowError()
+	singletonInstance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/recipe/thirdparty/recipe.go
+++ b/recipe/thirdparty/recipe.go
@@ -82,7 +82,7 @@ func recipeInit(config *tpmodels.TypeInput) supertokens.Recipe {
 	}
 }
 
-func getRecipeInstanceOrThrowError() (*Recipe, error) {
+func GetRecipeInstanceOrThrowError() (*Recipe, error) {
 	if singletonInstance != nil {
 		return singletonInstance, nil
 	}

--- a/recipe/thirdpartyemailpassword/config_test.go
+++ b/recipe/thirdpartyemailpassword/config_test.go
@@ -53,7 +53,7 @@ func TestDefaultConfigForThirdPartyEmailPasswordRecipe(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	thirdpartyemailpassword, err := getRecipeInstanceOrThrowError()
+	thirdpartyemailpassword, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -112,7 +112,7 @@ func TestDefaultConfigForThirdPartyEmailPasswordRecipeWithProvider(t *testing.T)
 		t.Error(err.Error())
 	}
 
-	thirdpartyemailpassword, err := getRecipeInstanceOrThrowError()
+	thirdpartyemailpassword, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/recipe/thirdpartyemailpassword/main.go
+++ b/recipe/thirdpartyemailpassword/main.go
@@ -28,7 +28,7 @@ func Init(config *tpepmodels.TypeInput) supertokens.Recipe {
 }
 
 func ThirdPartySignInUpWithContext(thirdPartyID string, thirdPartyUserID string, email string, userContext supertokens.UserContext) (tpepmodels.SignInUpResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tpepmodels.SignInUpResponse{}, err
 	}
@@ -36,7 +36,7 @@ func ThirdPartySignInUpWithContext(thirdPartyID string, thirdPartyUserID string,
 }
 
 func GetUserByThirdPartyInfoWithContext(thirdPartyID string, thirdPartyUserID string, userContext supertokens.UserContext) (*tpepmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func GetUserByThirdPartyInfoWithContext(thirdPartyID string, thirdPartyUserID st
 }
 
 func EmailPasswordSignUpWithContext(email, password string, userContext supertokens.UserContext) (tpepmodels.SignUpResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tpepmodels.SignUpResponse{}, err
 	}
@@ -52,7 +52,7 @@ func EmailPasswordSignUpWithContext(email, password string, userContext supertok
 }
 
 func EmailPasswordSignInWithContext(email, password string, userContext supertokens.UserContext) (tpepmodels.SignInResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tpepmodels.SignInResponse{}, err
 	}
@@ -60,7 +60,7 @@ func EmailPasswordSignInWithContext(email, password string, userContext supertok
 }
 
 func GetUserByIdWithContext(userID string, userContext supertokens.UserContext) (*tpepmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func GetUserByIdWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUsersByEmailWithContext(email string, userContext supertokens.UserContext) ([]tpepmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func GetUsersByEmailWithContext(email string, userContext supertokens.UserContex
 }
 
 func CreateResetPasswordTokenWithContext(userID string, userContext supertokens.UserContext) (epmodels.CreateResetPasswordTokenResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.CreateResetPasswordTokenResponse{}, err
 	}
@@ -84,7 +84,7 @@ func CreateResetPasswordTokenWithContext(userID string, userContext supertokens.
 }
 
 func ResetPasswordUsingTokenWithContext(token, newPassword string, userContext supertokens.UserContext) (epmodels.ResetPasswordUsingTokenResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.ResetPasswordUsingTokenResponse{}, err
 	}
@@ -92,7 +92,7 @@ func ResetPasswordUsingTokenWithContext(token, newPassword string, userContext s
 }
 
 func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.UpdateEmailOrPasswordResponse{}, err
 	}
@@ -100,7 +100,7 @@ func UpdateEmailOrPasswordWithContext(userId string, email *string, password *st
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -141,7 +141,7 @@ func recipeInit(config *tpepmodels.TypeInput) supertokens.Recipe {
 	}
 }
 
-func getRecipeInstanceOrThrowError() (*Recipe, error) {
+func GetRecipeInstanceOrThrowError() (*Recipe, error) {
 	if singletonInstance != nil {
 		return singletonInstance, nil
 	}

--- a/recipe/thirdpartypasswordless/config_test.go
+++ b/recipe/thirdpartypasswordless/config_test.go
@@ -79,7 +79,7 @@ func TestMinimumConfigForThirdPartyPasswordlessWithEmailOrPhoneContactMethod(t *
 		return
 	}
 
-	thirdPartyPasswordlessRecipe, err := getRecipeInstanceOrThrowError()
+	thirdPartyPasswordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", thirdPartyPasswordlessRecipe.Config.FlowType)
 }
@@ -355,7 +355,7 @@ func TestWithThirdPartyPasswordLessMinimumConfigWithEmailContactMethod(t *testin
 		return
 	}
 
-	thirdPartyPasswordlessRecipe, err := getRecipeInstanceOrThrowError()
+	thirdPartyPasswordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", thirdPartyPasswordlessRecipe.Config.FlowType)
 }

--- a/recipe/thirdpartypasswordless/main.go
+++ b/recipe/thirdpartypasswordless/main.go
@@ -31,7 +31,7 @@ func Init(config tplmodels.TypeInput) supertokens.Recipe {
 }
 
 func ThirdPartySignInUpWithContext(thirdPartyID string, thirdPartyUserID string, email string, userContext supertokens.UserContext) (tplmodels.ThirdPartySignInUp, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tplmodels.ThirdPartySignInUp{}, err
 	}
@@ -39,7 +39,7 @@ func ThirdPartySignInUpWithContext(thirdPartyID string, thirdPartyUserID string,
 }
 
 func GetUserByThirdPartyInfoWithContext(thirdPartyID string, thirdPartyUserID string, userContext supertokens.UserContext) (*tplmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func GetUserByThirdPartyInfoWithContext(thirdPartyID string, thirdPartyUserID st
 }
 
 func GetUserByIdWithContext(userID string, userContext supertokens.UserContext) (*tplmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func GetUserByIdWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUsersByEmailWithContext(email string, userContext supertokens.UserContext) ([]tplmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func GetUsersByEmailWithContext(email string, userContext supertokens.UserContex
 }
 
 func CreateCodeWithEmailWithContext(email string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.CreateCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.CreateCodeResponse{}, err
 	}
@@ -74,7 +74,7 @@ func CreateCodeWithEmailWithContext(email string, userInputCode *string, userCon
 }
 
 func CreateCodeWithPhoneNumberWithContext(phoneNumber string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.CreateCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.CreateCodeResponse{}, err
 	}
@@ -85,7 +85,7 @@ func CreateCodeWithPhoneNumberWithContext(phoneNumber string, userInputCode *str
 }
 
 func CreateNewCodeForDeviceWithContext(deviceID string, userInputCode *string, userContext supertokens.UserContext) (plessmodels.ResendCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.ResendCodeResponse{}, err
 	}
@@ -96,7 +96,7 @@ func CreateNewCodeForDeviceWithContext(deviceID string, userInputCode *string, u
 }
 
 func ConsumeCodeWithUserInputCodeWithContext(deviceID string, userInputCode string, preAuthSessionID string, userContext supertokens.UserContext) (tplmodels.ConsumeCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tplmodels.ConsumeCodeResponse{}, err
 	}
@@ -110,7 +110,7 @@ func ConsumeCodeWithUserInputCodeWithContext(deviceID string, userInputCode stri
 }
 
 func ConsumeCodeWithLinkCodeWithContext(linkCode string, preAuthSessionID string, userContext supertokens.UserContext) (tplmodels.ConsumeCodeResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return tplmodels.ConsumeCodeResponse{}, err
 	}
@@ -121,7 +121,7 @@ func ConsumeCodeWithLinkCodeWithContext(linkCode string, preAuthSessionID string
 }
 
 func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) (*tplmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func GetUserByIDWithContext(userID string, userContext supertokens.UserContext) 
 }
 
 func GetUserByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) (*tplmodels.User, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func GetUserByPhoneNumberWithContext(phoneNumber string, userContext supertokens
 }
 
 func UpdatePasswordlessUserWithContext(userID string, email *string, phoneNumber *string, userContext supertokens.UserContext) (plessmodels.UpdateUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.UpdateUserResponse{}, err
 	}
@@ -154,7 +154,7 @@ func UpdatePasswordlessUserWithContext(userID string, email *string, phoneNumber
 }
 
 func DeleteEmailForPasswordlessUserWithContext(userID string, userContext supertokens.UserContext) (plessmodels.DeleteUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.DeleteUserResponse{}, err
 	}
@@ -165,7 +165,7 @@ func DeleteEmailForPasswordlessUserWithContext(userID string, userContext supert
 }
 
 func DeletePhoneNumberForUserWithContext(userID string, userContext supertokens.UserContext) (plessmodels.DeleteUserResponse, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return plessmodels.DeleteUserResponse{}, err
 	}
@@ -176,7 +176,7 @@ func DeletePhoneNumberForUserWithContext(userID string, userContext supertokens.
 }
 
 func RevokeAllCodesByEmailWithContext(email string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func RevokeAllCodesByEmailWithContext(email string, userContext supertokens.User
 }
 
 func RevokeAllCodesByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func RevokeAllCodesByPhoneNumberWithContext(phoneNumber string, userContext supe
 }
 
 func RevokeCodeWithContext(codeID string, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func RevokeCodeWithContext(codeID string, userContext supertokens.UserContext) e
 }
 
 func ListCodesByEmailWithContext(email string, userContext supertokens.UserContext) ([]plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return []plessmodels.DeviceType{}, err
 	}
@@ -220,7 +220,7 @@ func ListCodesByEmailWithContext(email string, userContext supertokens.UserConte
 }
 
 func ListCodesByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) ([]plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return []plessmodels.DeviceType{}, err
 	}
@@ -231,7 +231,7 @@ func ListCodesByPhoneNumberWithContext(phoneNumber string, userContext supertoke
 }
 
 func ListCodesByDeviceIDWithContext(deviceID string, userContext supertokens.UserContext) (*plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func ListCodesByDeviceIDWithContext(deviceID string, userContext supertokens.Use
 }
 
 func ListCodesByPreAuthSessionIDWithContext(preAuthSessionID string, userContext supertokens.UserContext) (*plessmodels.DeviceType, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func ListCodesByPreAuthSessionIDWithContext(preAuthSessionID string, userContext
 }
 
 func CreateMagicLinkByEmailWithContext(email string, userContext supertokens.UserContext) (string, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return "", err
 	}
@@ -264,7 +264,7 @@ func CreateMagicLinkByEmailWithContext(email string, userContext supertokens.Use
 }
 
 func CreateMagicLinkByPhoneNumberWithContext(phoneNumber string, userContext supertokens.UserContext) (string, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return "", err
 	}
@@ -279,7 +279,7 @@ func PasswordlessSignInUpByEmailWithContext(email string, userContext supertoken
 	CreatedNewUser   bool
 	User             tplmodels.User
 }, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return struct {
 			PreAuthSessionID string
@@ -320,7 +320,7 @@ func PasswordlessSignInUpByPhoneNumberWithContext(phoneNumber string, userContex
 	CreatedNewUser   bool
 	User             tplmodels.User
 }, error) {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return struct {
 			PreAuthSessionID string
@@ -357,7 +357,7 @@ func PasswordlessSignInUpByPhoneNumberWithContext(phoneNumber string, userContex
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens
 }
 
 func SendSmsWithContext(input smsdelivery.SmsType, userContext supertokens.UserContext) error {
-	instance, err := getRecipeInstanceOrThrowError()
+	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return err
 	}

--- a/recipe/thirdpartypasswordless/provider_test.go
+++ b/recipe/thirdpartypasswordless/provider_test.go
@@ -81,7 +81,7 @@ func TestForThirdPartyPasswordlessTheMinimumConfigForThirdPartyProviderGoogle(t 
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -159,7 +159,7 @@ func TestWithThirdPartyPasswordlessPassingAdditionalParamsCheckTheyArePresentInA
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -229,7 +229,7 @@ func TestForThirdpartyPasswordlessPassingScopesInConfigForThirdpartyProviderGoog
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -296,7 +296,7 @@ func TestForThirdPartyPasswordlessMinimumConfigForThirdPartyProviderFacebook(t *
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -369,7 +369,7 @@ func TestWithThirdPartyPasswordlessPassingScopesInConfigForThirdPartyProviderFac
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -434,7 +434,7 @@ func TestWithThirdPartyPasswordlessMinimumConfigForThirdPartyProviderGithub(t *t
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -510,7 +510,7 @@ func TestWithThirdPartyPasswordlessParamCheckTheyArePresentInAuthorizationURLFor
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -579,7 +579,7 @@ func TestWithThirdPartyPasswordlessPassingScopesInConfigForThirdPartyProviderGit
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -648,7 +648,7 @@ func TestWithThirdPartyPasswordlessMinimumConfigForThirdPartyProviderApple(t *te
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -732,7 +732,7 @@ func TestWithThirdPartyPasswordlessPassingAdditionalParamsCheckTheyArePresentInA
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]
@@ -808,7 +808,7 @@ func TestWithThirdPartyProviderPasswordlessPassingScopesInConfigForThirdPartyPro
 		return
 	}
 
-	thirdpartypasswordlessrecipeinstance, err := getRecipeInstanceOrThrowError()
+	thirdpartypasswordlessrecipeinstance, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 
 	providerInfo := thirdpartypasswordlessrecipeinstance.Config.Providers[0]

--- a/recipe/thirdpartypasswordless/recipe.go
+++ b/recipe/thirdpartypasswordless/recipe.go
@@ -149,7 +149,7 @@ func recipeInit(config tplmodels.TypeInput) supertokens.Recipe {
 	}
 }
 
-func getRecipeInstanceOrThrowError() (*Recipe, error) {
+func GetRecipeInstanceOrThrowError() (*Recipe, error) {
 	if singletonInstance != nil {
 		return singletonInstance, nil
 	}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,10 +21,10 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.9.13"
+const VERSION = "0.9.14"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"}
 )
 
-const DashboardVersion = "0.2"
+const DashboardVersion = "0.3"


### PR DESCRIPTION
## Summary of change

- Fixes an issue where fetching user details for a passwordless user with only a phone number present would send the wrong response payload to the frontend
- Updates dashboard version to 0.3
- Updates user GET API in dashboard recipe to handle if the recipe for the user being fetched was not initialised

## Related issues

-  

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] 
