### PR TITLE
fix: Merge emailpassword formFields loops

### DIFF
--- a/recipe/emailpassword/api/implementation.go
+++ b/recipe/emailpassword/api/implementation.go
@@ -125,14 +125,11 @@ func MakeAPIImplementation() epmodels.APIInterface {
 
 	signInPOST := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignInPOSTResponse, error) {
 		var email string
+		var password string
 		for _, formField := range formFields {
 			if formField.ID == "email" {
 				email = formField.Value
-			}
-		}
-		var password string
-		for _, formField := range formFields {
-			if formField.ID == "password" {
+			} else if formField.ID == "password" {
 				password = formField.Value
 			}
 		}
@@ -166,14 +163,11 @@ func MakeAPIImplementation() epmodels.APIInterface {
 
 	signUpPOST := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignUpPOSTResponse, error) {
 		var email string
+		var password string
 		for _, formField := range formFields {
 			if formField.ID == "email" {
 				email = formField.Value
-			}
-		}
-		var password string
-		for _, formField := range formFields {
-			if formField.ID == "password" {
+			} else if formField.ID == "password" {
 				password = formField.Value
 			}
 		}


### PR DESCRIPTION
## Summary of change
Use the same loop to extract both email and password from formFields.

## Related issues
https://github.com/supertokens/supertokens-golang/issues/220

## Test Plan
Running locally, according to https://github.com/supertokens/supertokens-golang/blob/master/CONTRIBUTING.md#testing 

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

