### PR TITLE
fix: Refer to startTestEnv instead of startTestingEnv in contrib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ You will need to setup the `supertokens-core` in order to to run the `supertoken
 
 1. Navigate to the `supertokens-root` repository
 2. Start the testing environment  
-   `./startTestingEnv --wait`
+   `./startTestEnv --wait`
 3. Navigate to the `supertokens-golang` repository  
    `cd ../supertokens-golang/`
 4. Run all tests, [count=1 ensures tests are not cached]


### PR DESCRIPTION
## Summary of change
Refer to startTestEnv instead of startTestingEnv in contrib, according to https://github.com/supertokens/supertokens-root/commit/4baff668172055c74885f6f44359e6e3e8f0a78d

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
