### PR TITLE
fix: go fiber example fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Fixes issue with go-fiber example, where updating accessTokenPayload from user defined endpoint doesn't reflect in the response cookies.
+
 ## [0.9.14] - 2022-12-26
 
 -   Fixes an issue in the dashboard recipe when fetching user details for passwordless users that don't have an email associated with their accounts


### PR DESCRIPTION
## Summary of change

What was wrong in the previous solution we settled for is calling the c.Next() outside of the adaptor. The problem with that is that the session container is till working with http Request and and Response objects that were created inside the adaptor, but now no longer in use. I think the right thing to call the next from within the adaptor itself. We still address the previous issue by returning the error that was returned by the c.Next() outside the adaptor.

## Related issues

## Test Plan

Have verified user specified scenario. Also verified that the headers from user defined route and the SDK and the ones written directly to the net/http ResponseWriter are all reflecting in the resulting response correctly.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
