### PR TITLE
chore: Add dashboard init to example apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 -   Adds unit test for Apple callback form post
+-   Updates all example apps to also initialise dashboard recipe
 
 ## [0.10.2] - 2023-02-24
 -   Adds APIs and logic to the dashboard recipe to enable email password based login

--- a/examples/with-chi-oso/main.go
+++ b/examples/with-chi-oso/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/supertokens/supertokens-golang/examples/with-chi-oso/database"
 	"github.com/supertokens/supertokens-golang/examples/with-chi-oso/service"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification/evmodels"
 	"github.com/supertokens/supertokens-golang/recipe/session"
@@ -60,6 +61,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 	if err != nil {

--- a/examples/with-chi/main.go
+++ b/examples/with-chi/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification/evmodels"
 	"github.com/supertokens/supertokens-golang/recipe/session"
@@ -100,6 +101,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 

--- a/examples/with-fiber/main.go
+++ b/examples/with-fiber/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"log"
 	"net/http"
 
@@ -93,6 +94,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 	if err != nil {

--- a/examples/with-gin/config/config.go
+++ b/examples/with-gin/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"log"
 
 	"github.com/spf13/viper"
@@ -105,6 +106,7 @@ func Init() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 			// thirdparty.Init(thirdpartyConfig),
 		},
 	})

--- a/examples/with-go-zero/main.go
+++ b/examples/with-go-zero/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"log"
 	"net/http"
 	"strings"
@@ -92,6 +93,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 	if err != nil {

--- a/examples/with-http/main.go
+++ b/examples/with-http/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"net/http"
 	"strings"
 
@@ -91,6 +92,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 

--- a/examples/with-labstack-echo/main.go
+++ b/examples/with-labstack-echo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"net/http"
 	"strings"
 
@@ -94,6 +95,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 

--- a/examples/with-mux/main.go
+++ b/examples/with-mux/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"net/http"
 
 	"github.com/gorilla/handlers"
@@ -92,6 +93,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 

--- a/examples/with-twirp/cmd/server/main.go
+++ b/examples/with-twirp/cmd/server/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"log"
 	"net/http"
 	"os"
@@ -111,6 +112,7 @@ func main() {
 				},
 			}),
 			session.Init(nil),
+			dashboard.Init(nil),
 		},
 	})
 


### PR DESCRIPTION
## Summary of change

- Updates all example apps to also initialise the dashboard recipe

## Related issues


## Test Plan

NA

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
