### PR TITLE
refactor: Automatically initialise OpenId recipe in session recipe (JWT Rework #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Refactors the URL for the JWKS endpoint exposed by SuperTokens core
+-   The Session recipe now always initializes the OpenID recipe if it hasn't been initialized.
 
 ## [0.10.5] - 2023-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `useStaticSigningKey` to `CreateJWT` and `CreateJWTWithContext`
 -   Added support for CDI version `2.19`
 -   Dropped support for CDI version `2.8`-`2.18`
+-   JWT and OpenId related configuration has been removed from the Session recipe config. If necessary, they can be added by initializing the OpenId recipe before the Session recipe.
 
 ### Changed
 

--- a/recipe/session/claimsWithJWT_test.go
+++ b/recipe/session/claimsWithJWT_test.go
@@ -28,10 +28,6 @@ func TestJWTShouldCreateRightAccessTokenPayloadWithClaims(t *testing.T) {
 				GetTokenTransferMethod: func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) sessmodels.TokenTransferMethod {
 					return sessmodels.CookieTransferMethod
 				},
-
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable: true,
-				},
 				Override: &sessmodels.OverrideStruct{
 					Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
 						oCreateNewSession := *originalImplementation.CreateNewSession
@@ -119,8 +115,6 @@ func TestAssertClaimsWithPayloadWithJWTAndCallRightUpdateAccessTokenPayload(t *t
 				GetTokenTransferMethod: func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) sessmodels.TokenTransferMethod {
 					return sessmodels.CookieTransferMethod
 				},
-
-				Jwt: &sessmodels.JWTInputConfig{Enable: true},
 			}),
 		},
 	}
@@ -215,10 +209,6 @@ func TestMergeIntoAccessTokenPayloadForJWT(t *testing.T) {
 			Init(&sessmodels.TypeInput{
 				GetTokenTransferMethod: func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) sessmodels.TokenTransferMethod {
 					return sessmodels.CookieTransferMethod
-				},
-
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable: true,
 				},
 			}),
 		},

--- a/recipe/session/config_test.go
+++ b/recipe/session/config_test.go
@@ -918,11 +918,7 @@ func TestJwtFeatureEnabled(t *testing.T) {
 			WebsiteDomain: "supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			Init(&sessmodels.TypeInput{
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable: true,
-				},
-			}),
+			Init(&sessmodels.TypeInput{}),
 		},
 	}
 	BeforeEach()
@@ -951,11 +947,7 @@ func TestJwtFeatureDisabled(t *testing.T) {
 			WebsiteDomain: "supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			Init(&sessmodels.TypeInput{
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable: false,
-				},
-			}),
+			Init(nil),
 		},
 	}
 	BeforeEach()
@@ -973,41 +965,6 @@ func TestJwtFeatureDisabled(t *testing.T) {
 	assert.Equal(t, singletoneSessionRecipeInstance.Config.Jwt.Enable, false)
 }
 
-func TestJWTPropertyNameIsAccesedWhenSet(t *testing.T) {
-	customJWTKey := "customJWTKey"
-	configValue := supertokens.TypeInput{
-		Supertokens: &supertokens.ConnectionInfo{
-			ConnectionURI: "http://localhost:8080",
-		},
-		AppInfo: supertokens.AppInfo{
-			APIDomain:     "api.supertokens.io",
-			AppName:       "SuperTokens",
-			WebsiteDomain: "supertokens.io",
-		},
-		RecipeList: []supertokens.Recipe{
-			Init(&sessmodels.TypeInput{
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable:                           true,
-					PropertyNameInAccessTokenPayload: &customJWTKey,
-				},
-			}),
-		},
-	}
-	BeforeEach()
-	unittesting.StartUpST("localhost", "8080")
-	defer AfterEach()
-	err := supertokens.Init(configValue)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	singletoneSessionRecipeInstance, err := getRecipeInstanceOrThrowError()
-	if err != nil {
-		t.Error(err.Error())
-	}
-	assert.Nil(t, singletoneSessionRecipeInstance.Config.Jwt.Issuer)
-	assert.Equal(t, singletoneSessionRecipeInstance.Config.Jwt.PropertyNameInAccessTokenPayload, "customJWTKey")
-}
-
 func TestJWTPropertyNameIsSetCorrectlyByDefault(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{
@@ -1019,11 +976,7 @@ func TestJWTPropertyNameIsSetCorrectlyByDefault(t *testing.T) {
 			WebsiteDomain: "supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			Init(&sessmodels.TypeInput{
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable: true,
-				},
-			}),
+			Init(nil),
 		},
 	}
 	BeforeEach()
@@ -1039,37 +992,6 @@ func TestJWTPropertyNameIsSetCorrectlyByDefault(t *testing.T) {
 	}
 	assert.Nil(t, singletoneSessionRecipeInstance.Config.Jwt.Issuer)
 	assert.Equal(t, singletoneSessionRecipeInstance.Config.Jwt.PropertyNameInAccessTokenPayload, "jwt")
-}
-
-func TestJWTPropertyThrowsErrorWhenGetsReservedName(t *testing.T) {
-	customJWTKey := "_jwtPName"
-	configValue := supertokens.TypeInput{
-		Supertokens: &supertokens.ConnectionInfo{
-			ConnectionURI: "http://localhost:8080",
-		},
-		AppInfo: supertokens.AppInfo{
-			APIDomain:     "api.supertokens.io",
-			AppName:       "SuperTokens",
-			WebsiteDomain: "supertokens.io",
-		},
-		RecipeList: []supertokens.Recipe{
-			Init(&sessmodels.TypeInput{
-				Jwt: &sessmodels.JWTInputConfig{
-					Enable:                           true,
-					PropertyNameInAccessTokenPayload: &customJWTKey,
-				},
-			}),
-		},
-	}
-	BeforeEach()
-	unittesting.StartUpST("localhost", "8080")
-	defer AfterEach()
-	err := supertokens.Init(configValue)
-	if err != nil {
-		assert.Equal(t, err.Error(), "_jwtPName is a reserved property name, please use a different key name for the jwt")
-	} else {
-		t.Fail()
-	}
 }
 
 func TestSuperTokensInitWithAPIGateWayPath(t *testing.T) {

--- a/recipe/session/main.go
+++ b/recipe/session/main.go
@@ -17,7 +17,6 @@ package session
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/supertokens/supertokens-golang/recipe/jwt/jwtmodels"
@@ -150,9 +149,7 @@ func CreateJWTWithContext(payload map[string]interface{}, validitySecondsPointer
 	if err != nil {
 		return jwtmodels.CreateJWTResponse{}, err
 	}
-	if instance.OpenIdRecipe == nil {
-		return jwtmodels.CreateJWTResponse{}, errors.New("CreateJWT cannot be used without enabling the Jwt feature")
-	}
+
 	return (*instance.OpenIdRecipe.RecipeImpl.CreateJWT)(payload, validitySecondsPointer, userContext, useStaticSigningKey)
 }
 
@@ -161,9 +158,7 @@ func GetJWKSWithContext(userContext supertokens.UserContext) (jwtmodels.GetJWKSR
 	if err != nil {
 		return jwtmodels.GetJWKSResponse{}, err
 	}
-	if instance.OpenIdRecipe == nil {
-		return jwtmodels.GetJWKSResponse{}, errors.New("GetJWKS cannot be used without enabling the Jwt feature")
-	}
+
 	return (*instance.OpenIdRecipe.RecipeImpl.GetJWKS)(userContext)
 }
 
@@ -172,9 +167,7 @@ func GetOpenIdDiscoveryConfigurationWithContext(userContext supertokens.UserCont
 	if err != nil {
 		return openidmodels.GetOpenIdDiscoveryConfigurationResponse{}, err
 	}
-	if instance.OpenIdRecipe == nil {
-		return openidmodels.GetOpenIdDiscoveryConfigurationResponse{}, errors.New("GetOpenIdDiscoveryConfiguration cannot be used without enabling the Jwt feature")
-	}
+
 	return (*instance.OpenIdRecipe.RecipeImpl.GetOpenIdDiscoveryConfiguration)(userContext)
 }
 

--- a/recipe/session/sessmodels/models.go
+++ b/recipe/session/sessmodels/models.go
@@ -111,14 +111,7 @@ type TypeInput struct {
 	AntiCsrf                 *string
 	Override                 *OverrideStruct
 	ErrorHandlers            *ErrorHandlers
-	Jwt                      *JWTInputConfig
 	GetTokenTransferMethod   func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) TokenTransferMethod
-}
-
-type JWTInputConfig struct {
-	Issuer                           *string
-	Enable                           bool
-	PropertyNameInAccessTokenPayload *string
 }
 
 type OverrideStruct struct {

--- a/recipe/session/utils.go
+++ b/recipe/session/utils.go
@@ -150,13 +150,6 @@ func validateAndNormaliseUserInput(appInfo supertokens.NormalisedAppinfo, config
 	}
 
 	Jwt := sessmodels.JWTNormalisedConfig{Enable: false, PropertyNameInAccessTokenPayload: "jwt"}
-	if config != nil && config.Jwt != nil {
-		Jwt.Enable = config.Jwt.Enable
-		Jwt.Issuer = config.Jwt.Issuer
-		if config.Jwt.PropertyNameInAccessTokenPayload != nil {
-			Jwt.PropertyNameInAccessTokenPayload = *config.Jwt.PropertyNameInAccessTokenPayload
-		}
-	}
 	if sessionwithjwt.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY == Jwt.PropertyNameInAccessTokenPayload {
 		return sessmodels.TypeNormalisedInput{}, errors.New(sessionwithjwt.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY + " is a reserved property name, please use a different key name for the jwt")
 	}

--- a/test/frontendIntegration/main.go
+++ b/test/frontendIntegration/main.go
@@ -81,10 +81,6 @@ func callSTInit(enableAntiCsrf bool, enableJWT bool, jwtPropertyName string) {
 			},
 			RecipeList: []supertokens.Recipe{
 				session.Init(&sessmodels.TypeInput{
-					Jwt: &sessmodels.JWTInputConfig{
-						Enable:                           true,
-						PropertyNameInAccessTokenPayload: &jwtPropertyName,
-					},
 					ErrorHandlers: &sessmodels.ErrorHandlers{
 						OnUnauthorised: func(message string, req *http.Request, res http.ResponseWriter) error {
 							res.Header().Set("Content-Type", "text/html; charset=utf-8")


### PR DESCRIPTION
## Summary of change

- The session recipe not always initialised the open id recipe if it isnt already initialised
- The session recipe config no longer accepts the `jwt` property

NOTE: The jwt property is removed from the user facing input but not the normalised version of it because the jwt is still present in the access token payload. In a future PR this will be cleaned up when the jwt is removed from the access token

## Related issues


## Test Plan


## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
