### PR TITLE
feat: optional password validation in updateEmailOrPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.0] - 2023-05-03
+- added optional password policy check in `updateEmailOrPassword`
+
 ## [0.11.0] - 2023-04-28
 - Added missing arguments in `GetUsersNewestFirst` and `GetUsersOldestFirst`
 

--- a/recipe/dashboard/api/userdetails/userPut.go
+++ b/recipe/dashboard/api/userdetails/userPut.go
@@ -74,7 +74,7 @@ func updateEmailForRecipeId(recipeId string, userId string, email string) (updat
 			}, nil
 		}
 
-		updateResponse, err := emailpassword.UpdateEmailOrPassword(userId, &email, nil)
+		updateResponse, err := emailpassword.UpdateEmailOrPassword(userId, &email, nil, nil)
 
 		if err != nil {
 			return updateEmailResponse{}, err
@@ -113,7 +113,7 @@ func updateEmailForRecipeId(recipeId string, userId string, email string) (updat
 			}, nil
 		}
 
-		updateResponse, err := thirdpartyemailpassword.UpdateEmailOrPassword(userId, &email, nil)
+		updateResponse, err := thirdpartyemailpassword.UpdateEmailOrPassword(userId, &email, nil, nil)
 
 		if err != nil {
 			return updateEmailResponse{}, err

--- a/recipe/emailpassword/authFlow_test.go
+++ b/recipe/emailpassword/authFlow_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/supertokens/supertokens-golang/test/unittesting"
 )
 
-//SigninFeature Tests
+// SigninFeature Tests
 func TestDisablingAPIDefaultSigninDoesNotWork(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{
@@ -1234,7 +1234,7 @@ func TestHandlePostSignInFunction(t *testing.T) {
 
 }
 
-//Signout Feature tests
+// Signout Feature tests
 func TestDefaultSignoutRouteRevokesSession(t *testing.T) {
 	customAntiCsrfVal := "VIA_TOKEN"
 	configValue := supertokens.TypeInput{
@@ -1474,7 +1474,7 @@ func TestSignoutAPIreturnsTryRefreshTokenAndSignoutShouldReturnOK(t *testing.T) 
 	assert.Equal(t, "", cookieData2["refreshTokenDomain"])
 }
 
-//Signup Feature tests
+// Signup Feature tests
 func TestDisablingAPIDefaultSignUpDoesNotWork(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{

--- a/recipe/emailpassword/ep_userIdMapping_test.go
+++ b/recipe/emailpassword/ep_userIdMapping_test.go
@@ -188,7 +188,7 @@ func TestCreateUserIdMappingUpdateEmailPassword(t *testing.T) {
 
 	newEmail := "email@example.com"
 	newPass := "newpass123"
-	updateResp, err := UpdateEmailOrPassword(externalUserId, &newEmail, &newPass)
+	updateResp, err := UpdateEmailOrPassword(externalUserId, &newEmail, &newPass, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, updateResp.OK)
 

--- a/recipe/emailpassword/epmodels/recipeInterface.go
+++ b/recipe/emailpassword/epmodels/recipeInterface.go
@@ -59,5 +59,9 @@ type UpdateEmailOrPasswordResponse struct {
 	OK                          *struct{}
 	UnknownUserIdError          *struct{}
 	EmailAlreadyExistsError     *struct{}
-	PasswordPolicyViolatedError *struct{}
+	PasswordPolicyViolatedError *PasswordPolicyViolatedError
+}
+
+type PasswordPolicyViolatedError struct {
+	FailureReason *string
 }

--- a/recipe/emailpassword/epmodels/recipeInterface.go
+++ b/recipe/emailpassword/epmodels/recipeInterface.go
@@ -24,7 +24,7 @@ type RecipeInterface struct {
 	GetUserByEmail           *func(email string, userContext supertokens.UserContext) (*User, error)
 	CreateResetPasswordToken *func(userID string, userContext supertokens.UserContext) (CreateResetPasswordTokenResponse, error)
 	ResetPasswordUsingToken  *func(token string, newPassword string, userContext supertokens.UserContext) (ResetPasswordUsingTokenResponse, error)
-	UpdateEmailOrPassword    *func(userId string, email *string, password *string, userContext supertokens.UserContext) (UpdateEmailOrPasswordResponse, error)
+	UpdateEmailOrPassword    *func(userId string, email *string, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (UpdateEmailOrPasswordResponse, error)
 }
 
 type SignUpResponse struct {
@@ -56,7 +56,8 @@ type ResetPasswordUsingTokenResponse struct {
 }
 
 type UpdateEmailOrPasswordResponse struct {
-	OK                      *struct{}
-	UnknownUserIdError      *struct{}
-	EmailAlreadyExistsError *struct{}
+	OK                          *struct{}
+	UnknownUserIdError          *struct{}
+	EmailAlreadyExistsError     *struct{}
+	PasswordPolicyViolatedError *struct{}
 }

--- a/recipe/emailpassword/epmodels/recipeInterface.go
+++ b/recipe/emailpassword/epmodels/recipeInterface.go
@@ -63,5 +63,5 @@ type UpdateEmailOrPasswordResponse struct {
 }
 
 type PasswordPolicyViolatedError struct {
-	FailureReason *string
+	FailureReason string
 }

--- a/recipe/emailpassword/main.go
+++ b/recipe/emailpassword/main.go
@@ -74,12 +74,12 @@ func ResetPasswordUsingTokenWithContext(token string, newPassword string, userCo
 	return (*instance.RecipeImpl.ResetPasswordUsingToken)(token, newPassword, userContext)
 }
 
-func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
+func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
 	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.UpdateEmailOrPasswordResponse{}, nil
 	}
-	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, userContext)
+	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, applyPasswordPolicy, userContext)
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
@@ -114,8 +114,8 @@ func ResetPasswordUsingToken(token string, newPassword string) (epmodels.ResetPa
 	return ResetPasswordUsingTokenWithContext(token, newPassword, &map[string]interface{}{})
 }
 
-func UpdateEmailOrPassword(userId string, email *string, password *string) (epmodels.UpdateEmailOrPasswordResponse, error) {
-	return UpdateEmailOrPasswordWithContext(userId, email, password, &map[string]interface{}{})
+func UpdateEmailOrPassword(userId string, email *string, password *string, applyPasswordPolicy *bool) (epmodels.UpdateEmailOrPasswordResponse, error) {
+	return UpdateEmailOrPasswordWithContext(userId, email, password, applyPasswordPolicy, &map[string]interface{}{})
 }
 
 func SendEmail(input emaildelivery.EmailType) error {

--- a/recipe/emailpassword/recipe.go
+++ b/recipe/emailpassword/recipe.go
@@ -53,7 +53,10 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 	verifiedConfig := validateAndNormaliseUserInput(r, appInfo, config)
 	r.Config = verifiedConfig
 	r.APIImpl = verifiedConfig.Override.APIs(api.MakeAPIImplementation())
-	r.RecipeImpl = verifiedConfig.Override.Functions(MakeRecipeImplementation(*querierInstance))
+	var getEmailPasswordConfig = func() epmodels.TypeNormalisedInput {
+		return verifiedConfig
+	}
+	r.RecipeImpl = verifiedConfig.Override.Functions(MakeRecipeImplementation(*querierInstance, getEmailPasswordConfig))
 
 	if emailDeliveryIngredient != nil {
 		r.EmailDelivery = *emailDeliveryIngredient

--- a/recipe/emailpassword/recipeImplementation.go
+++ b/recipe/emailpassword/recipeImplementation.go
@@ -16,7 +16,6 @@
 package emailpassword
 
 import (
-	"errors"
 	"github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
 )
@@ -171,9 +170,12 @@ func MakeRecipeImplementation(querier supertokens.Querier, getEmailPasswordConfi
 				formFields := getEmailPasswordConfig().SignUpFeature.FormFields
 				for i := range formFields {
 					if formFields[i].ID == "password" {
-						err := formFields[i].Validate(password)
-						if err == nil {
-							return epmodels.UpdateEmailOrPasswordResponse{PasswordPolicyViolatedError: &struct{}{}}, errors.New(*err)
+						err := formFields[i].Validate(*password)
+						if err != nil {
+							errResponse := epmodels.PasswordPolicyViolatedError{
+								FailureReason: err,
+							}
+							return epmodels.UpdateEmailOrPasswordResponse{PasswordPolicyViolatedError: &errResponse}, nil
 						}
 					}
 				}

--- a/recipe/emailpassword/recipeImplementation.go
+++ b/recipe/emailpassword/recipeImplementation.go
@@ -173,7 +173,7 @@ func MakeRecipeImplementation(querier supertokens.Querier, getEmailPasswordConfi
 						err := formFields[i].Validate(*password)
 						if err != nil {
 							errResponse := epmodels.PasswordPolicyViolatedError{
-								FailureReason: err,
+								FailureReason: *err,
 							}
 							return epmodels.UpdateEmailOrPasswordResponse{PasswordPolicyViolatedError: &errResponse}, nil
 						}

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -100,7 +100,7 @@ func TestUpdateEmailPass(t *testing.T) {
 	email := "test2@gmail.com"
 	password := "testPass"
 
-	UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password)
+	UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password, nil)
 
 	res1, err := unittesting.SignInRequest("testrandom@gmail.com", "validpass123", testServer.URL)
 

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -147,6 +147,90 @@ func TestUpdateEmailPass(t *testing.T) {
 	assert.Equal(t, "Password must contain at least 8 characters, including a number", res3.PasswordPolicyViolatedError.FailureReason)
 }
 
+func TestUpdateEmailPassWithCustomValidator(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{SignUpFeature: &epmodels.TypeInputSignUp{FormFields: []epmodels.TypeInputFormField{
+				{
+					ID: "password",
+					Validate: func(value interface{}) *string {
+						if len(value.(string)) > 5 {
+							return nil
+						}
+						err := "Password length must be more than 5 characters"
+						return &err
+					},
+				},
+			}}}),
+			session.Init(&sessmodels.TypeInput{
+				GetTokenTransferMethod: func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) sessmodels.TokenTransferMethod {
+					return sessmodels.CookieTransferMethod
+				},
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if unittesting.MaxVersion("2.7", cdiVersion) == "2.7" {
+		return
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	_, err = unittesting.SignupRequest("testrandom@gmail.com", "validpass123", testServer.URL)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	res, err := unittesting.SignInRequest("testrandom@gmail.com", "validpass123", testServer.URL)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+	dataInBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	res.Body.Close()
+
+	var data map[string]interface{}
+	err = json.Unmarshal(dataInBytes, &data)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	email := "testrandom@gmail.com"
+	password := "test"
+
+	res1, err := UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password, nil)
+	assert.NotNil(t, res1.PasswordPolicyViolatedError)
+	assert.Equal(t, "Password length must be more than 5 characters", res1.PasswordPolicyViolatedError.FailureReason)
+
+}
+
 func TestAPICustomResponse(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -144,7 +144,7 @@ func TestUpdateEmailPass(t *testing.T) {
 	applyPasswordPolicy := true
 	res3, err := UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password, &applyPasswordPolicy)
 	assert.NotNil(t, res3.PasswordPolicyViolatedError)
-	assert.Equal(t, "Password must contain at least 8 characters, including a number", *res3.PasswordPolicyViolatedError.FailureReason)
+	assert.Equal(t, "Password must contain at least 8 characters, including a number", res3.PasswordPolicyViolatedError.FailureReason)
 }
 
 func TestAPICustomResponse(t *testing.T) {

--- a/recipe/emailpassword/updateEmailPass_test.go
+++ b/recipe/emailpassword/updateEmailPass_test.go
@@ -98,10 +98,9 @@ func TestUpdateEmailPass(t *testing.T) {
 	}
 
 	email := "test2@gmail.com"
-	password := "testPass"
+	password := "testPass1"
 
 	UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password, nil)
-
 	res1, err := unittesting.SignInRequest("testrandom@gmail.com", "validpass123", testServer.URL)
 
 	if err != nil {
@@ -140,6 +139,12 @@ func TestUpdateEmailPass(t *testing.T) {
 
 	assert.Equal(t, "OK", data2["status"])
 	assert.Equal(t, email, data2["user"].(map[string]interface{})["email"])
+
+	password = "test"
+	applyPasswordPolicy := true
+	res3, err := UpdateEmailOrPassword(data["user"].(map[string]interface{})["id"].(string), &email, &password, &applyPasswordPolicy)
+	assert.NotNil(t, res3.PasswordPolicyViolatedError)
+	assert.Equal(t, "Password must contain at least 8 characters, including a number", *res3.PasswordPolicyViolatedError.FailureReason)
 }
 
 func TestAPICustomResponse(t *testing.T) {

--- a/recipe/thirdpartyemailpassword/main.go
+++ b/recipe/thirdpartyemailpassword/main.go
@@ -91,12 +91,12 @@ func ResetPasswordUsingTokenWithContext(token, newPassword string, userContext s
 	return (*instance.RecipeImpl.ResetPasswordUsingToken)(token, newPassword, userContext)
 }
 
-func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, applyPasswordPOlicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
+func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
 	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.UpdateEmailOrPasswordResponse{}, err
 	}
-	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, applyPasswordPOlicy, userContext)
+	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, applyPasswordPolicy, userContext)
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {

--- a/recipe/thirdpartyemailpassword/main.go
+++ b/recipe/thirdpartyemailpassword/main.go
@@ -91,12 +91,12 @@ func ResetPasswordUsingTokenWithContext(token, newPassword string, userContext s
 	return (*instance.RecipeImpl.ResetPasswordUsingToken)(token, newPassword, userContext)
 }
 
-func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
+func UpdateEmailOrPasswordWithContext(userId string, email *string, password *string, applyPasswordPOlicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
 	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
 		return epmodels.UpdateEmailOrPasswordResponse{}, err
 	}
-	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, userContext)
+	return (*instance.RecipeImpl.UpdateEmailOrPassword)(userId, email, password, applyPasswordPOlicy, userContext)
 }
 
 func SendEmailWithContext(input emaildelivery.EmailType, userContext supertokens.UserContext) error {
@@ -139,8 +139,8 @@ func ResetPasswordUsingToken(token, newPassword string) (epmodels.ResetPasswordU
 	return ResetPasswordUsingTokenWithContext(token, newPassword, &map[string]interface{}{})
 }
 
-func UpdateEmailOrPassword(userId string, email *string, password *string) (epmodels.UpdateEmailOrPasswordResponse, error) {
-	return UpdateEmailOrPasswordWithContext(userId, email, password, &map[string]interface{}{})
+func UpdateEmailOrPassword(userId string, email *string, password *string, applyPasswordPolicy *bool) (epmodels.UpdateEmailOrPasswordResponse, error) {
+	return UpdateEmailOrPasswordWithContext(userId, email, password, applyPasswordPolicy, &map[string]interface{}{})
 }
 
 func SendEmail(input emaildelivery.EmailType) error {

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -54,6 +54,7 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 		return Recipe{}, err
 	}
 	r.Config = verifiedConfig
+	var emailPasswordRecipe emailpassword.Recipe
 	{
 		emailpasswordquerierInstance, err := supertokens.GetNewQuerierInstanceOrThrowError(emailpassword.RECIPE_ID)
 		if err != nil {
@@ -63,14 +64,14 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 		if err != nil {
 			return Recipe{}, err
 		}
-
-		r.RecipeImpl = verifiedConfig.Override.Functions(recipeimplementation.MakeRecipeImplementation(*emailpasswordquerierInstance, thirdpartyquerierInstance))
+		var getEmailPasswordConfig = func() epmodels.TypeNormalisedInput {
+			return emailPasswordRecipe.Config
+		}
+		r.RecipeImpl = verifiedConfig.Override.Functions(recipeimplementation.MakeRecipeImplementation(*emailpasswordquerierInstance, thirdpartyquerierInstance, getEmailPasswordConfig))
 	}
 	r.APIImpl = verifiedConfig.Override.APIs(api.MakeAPIImplementation())
 
-	var emailPasswordRecipe emailpassword.Recipe
 	emailPasswordRecipeImpl := recipeimplementation.MakeEmailPasswordRecipeImplementation(r.RecipeImpl)
-
 	if emailDeliveryIngredient != nil {
 		r.EmailDelivery = *emailDeliveryIngredient
 	} else {

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -54,7 +54,6 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 		return Recipe{}, err
 	}
 	r.Config = verifiedConfig
-	var emailPasswordRecipe emailpassword.Recipe
 	{
 		emailpasswordquerierInstance, err := supertokens.GetNewQuerierInstanceOrThrowError(emailpassword.RECIPE_ID)
 		if err != nil {
@@ -71,6 +70,7 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 	}
 	r.APIImpl = verifiedConfig.Override.APIs(api.MakeAPIImplementation())
 
+	var emailPasswordRecipe emailpassword.Recipe
 	emailPasswordRecipeImpl := recipeimplementation.MakeEmailPasswordRecipeImplementation(r.RecipeImpl)
 	if emailDeliveryIngredient != nil {
 		r.EmailDelivery = *emailDeliveryIngredient

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -65,7 +65,7 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 			return Recipe{}, err
 		}
 		var getEmailPasswordConfig = func() epmodels.TypeNormalisedInput {
-			return emailPasswordRecipe.Config
+			return r.emailPasswordRecipe.Config
 		}
 		r.RecipeImpl = verifiedConfig.Override.Functions(recipeimplementation.MakeRecipeImplementation(*emailpasswordquerierInstance, thirdpartyquerierInstance, getEmailPasswordConfig))
 	}

--- a/recipe/thirdpartyemailpassword/recipeimplementation/emailPasswordRecipeImplementation.go
+++ b/recipe/thirdpartyemailpassword/recipeimplementation/emailPasswordRecipeImplementation.go
@@ -106,8 +106,8 @@ func MakeEmailPasswordRecipeImplementation(recipeImplementation tpepmodels.Recip
 		return (*recipeImplementation.ResetPasswordUsingToken)(token, newPassword, userContext)
 	}
 
-	updateEmailOrPassword := func(userId string, email, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
-		return (*recipeImplementation.UpdateEmailOrPassword)(userId, email, password, userContext)
+	updateEmailOrPassword := func(userId string, email, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
+		return (*recipeImplementation.UpdateEmailOrPassword)(userId, email, password, applyPasswordPolicy, userContext)
 	}
 
 	return epmodels.RecipeInterface{

--- a/recipe/thirdpartyemailpassword/recipeimplementation/main.go
+++ b/recipe/thirdpartyemailpassword/recipeimplementation/main.go
@@ -26,10 +26,9 @@ import (
 	"github.com/supertokens/supertokens-golang/supertokens"
 )
 
-func MakeRecipeImplementation(emailPasswordQuerier supertokens.Querier, thirdPartyQuerier *supertokens.Querier) tpepmodels.RecipeInterface {
+func MakeRecipeImplementation(emailPasswordQuerier supertokens.Querier, thirdPartyQuerier *supertokens.Querier, getEmailPasswordConfig func() epmodels.TypeNormalisedInput) tpepmodels.RecipeInterface {
 	result := tpepmodels.RecipeInterface{}
-
-	emailPasswordImplementation := emailpassword.MakeRecipeImplementation(emailPasswordQuerier)
+	emailPasswordImplementation := emailpassword.MakeRecipeImplementation(emailPasswordQuerier, getEmailPasswordConfig)
 	var thirdPartyImplementation *tpmodels.RecipeInterface
 	if thirdPartyQuerier != nil {
 		thirdPartyImplementationTemp := thirdparty.MakeRecipeImplementation(*thirdPartyQuerier)
@@ -228,7 +227,7 @@ func MakeRecipeImplementation(emailPasswordQuerier supertokens.Querier, thirdPar
 	}
 
 	ogUpdateEmailOrPassword := *emailPasswordImplementation.UpdateEmailOrPassword
-	updateEmailOrPassword := func(userId string, email, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
+	updateEmailOrPassword := func(userId string, email, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error) {
 		user, err := (*result.GetUserByID)(userId, userContext)
 		if err != nil {
 			return epmodels.UpdateEmailOrPasswordResponse{}, err
@@ -242,7 +241,7 @@ func MakeRecipeImplementation(emailPasswordQuerier supertokens.Querier, thirdPar
 			return epmodels.UpdateEmailOrPasswordResponse{}, errors.New("cannot update email or password of a user who signed up using third party login")
 		}
 
-		return ogUpdateEmailOrPassword(userId, email, password, userContext)
+		return ogUpdateEmailOrPassword(userId, email, password, applyPasswordPolicy, userContext)
 	}
 
 	result.GetUserByID = &getUserByID

--- a/recipe/thirdpartyemailpassword/tpepmodels/recipeInterface.go
+++ b/recipe/thirdpartyemailpassword/tpepmodels/recipeInterface.go
@@ -29,7 +29,7 @@ type RecipeInterface struct {
 	EmailPasswordSignIn      *func(email string, password string, userContext supertokens.UserContext) (SignInResponse, error)
 	CreateResetPasswordToken *func(userID string, userContext supertokens.UserContext) (epmodels.CreateResetPasswordTokenResponse, error)
 	ResetPasswordUsingToken  *func(token string, newPassword string, userContext supertokens.UserContext) (epmodels.ResetPasswordUsingTokenResponse, error)
-	UpdateEmailOrPassword    *func(userId string, email *string, password *string, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error)
+	UpdateEmailOrPassword    *func(userId string, email *string, password *string, applyPasswordPolicy *bool, userContext supertokens.UserContext) (epmodels.UpdateEmailOrPasswordResponse, error)
 }
 
 type SignInUpResponse struct {

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.11.0"
+const VERSION = "0.12.0"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18", "2.19", "2.20"}


### PR DESCRIPTION
## Summary of change
Added optional password validation in `updateEmailOrPassword` function.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/549 (same implemented for golang)

## Test Plan


## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
