### PR TITLE
chore: Add test for verify session calling the core

### DIFF
--- a/recipe/session/recipe.go
+++ b/recipe/session/recipe.go
@@ -225,4 +225,5 @@ func (r *Recipe) getClaimValidatorsAddedByOtherRecipes() []claims.SessionClaimVa
 
 func ResetForTest() {
 	singletonInstance = nil
+	didGetSessionCallCore = false
 }

--- a/recipe/session/recipe.go
+++ b/recipe/session/recipe.go
@@ -225,5 +225,4 @@ func (r *Recipe) getClaimValidatorsAddedByOtherRecipes() []claims.SessionClaimVa
 
 func ResetForTest() {
 	singletonInstance = nil
-	didGetSessionCallCore = false
 }

--- a/recipe/session/sessionFunctions.go
+++ b/recipe/session/sessionFunctions.go
@@ -156,6 +156,9 @@ func getSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens
 		requestBody["antiCsrfToken"] = *antiCsrfToken
 	}
 
+	if supertokens.IsRunningInTestMode() {
+		didGetSessionCallCore = true
+	}
 	response, err := querier.SendPostRequest("/recipe/session/verify", requestBody)
 	if err != nil {
 		return sessmodels.GetSessionResponse{}, err

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -22,6 +22,9 @@ import (
 	"github.com/supertokens/supertokens-golang/test/unittesting"
 )
 
+// Testing constants
+var didGetSessionCallCore = false
+
 func resetAll() {
 	supertokens.ResetForTest()
 	ResetForTest()

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -28,6 +28,7 @@ var didGetSessionCallCore = false
 func resetAll() {
 	supertokens.ResetForTest()
 	ResetForTest()
+	didGetSessionCallCore = false
 }
 
 func BeforeEach() {

--- a/recipe/session/verifySession_test.go
+++ b/recipe/session/verifySession_test.go
@@ -878,6 +878,7 @@ func TestThatVerifySessionDoesNotAlwaysCallCore(t *testing.T) {
 		t.Error(err.Error())
 	}
 
+	assert.False(t, didGetSessionCallCore)
 	tokensAfterRefresh := refreshResp.GetAllSessionTokensDangerously()
 	assert.True(t, tokensAfterRefresh.AccessToken != "")
 	assert.True(t, *tokensAfterRefresh.RefreshToken != "")


### PR DESCRIPTION
## Summary of change

- Adds a test to make sure that the SDK does not always call the core during session verification

## Related issues
- 

## Test Plan
New tests added

## Documentation changes


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] 
