### PR TITLE
feat!: make loading access token from the request overrideable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.1] - 2023-05-12
+
+### Changes
+
+-   Made the access token string optional in the overrideable `GetSession` function
+-   Moved checking if the access token is nil into the overrideable `GetSession` function
+
 ## [0.12.0] - 2023-05-05
 
 ### Added

--- a/recipe/session/main.go
+++ b/recipe/session/main.go
@@ -90,7 +90,7 @@ func GetSessionWithContextWithoutRequestResponse(accessToken string, antiCSRFTok
 		return nil, err
 	}
 
-	result, err := (*instance.RecipeImpl.GetSession)(accessToken, antiCSRFToken, options, userContext)
+	result, err := (*instance.RecipeImpl.GetSession)(&accessToken, antiCSRFToken, options, userContext)
 
 	if err != nil {
 		return nil, err

--- a/recipe/session/sessionRequestFunctions.go
+++ b/recipe/session/sessionRequestFunctions.go
@@ -246,6 +246,11 @@ func GetSessionFromRequest(req *http.Request, res http.ResponseWriter, config se
 			return nil, err
 		}
 
+		// requestTransferMethod can only be nil here if the user has overridden GetSession
+		// to load the session by a custom method in that (very niche) case they also need to
+		// override how the session is attached to the response.
+		// In that scenario the transferMethod passed to attachToRequestResponse likely doesn't
+		// matter, still, we follow the general fallback logic
 		transferMethod := sessmodels.HeaderTransferMethod
 
 		if requestTokenTransferMethod != nil {

--- a/recipe/session/sessmodels/recipeInterface.go
+++ b/recipe/session/sessmodels/recipeInterface.go
@@ -22,7 +22,7 @@ import (
 
 type RecipeInterface struct {
 	CreateNewSession            *func(userID string, accessTokenPayload map[string]interface{}, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (SessionContainer, error)
-	GetSession                  *func(accessToken string, antiCSRFToken *string, options *VerifySessionOptions, userContext supertokens.UserContext) (SessionContainer, error)
+	GetSession                  *func(accessToken *string, antiCSRFToken *string, options *VerifySessionOptions, userContext supertokens.UserContext) (SessionContainer, error)
 	RefreshSession              *func(refreshToken string, antiCSRFToken *string, disableAntiCSRF bool, userContext supertokens.UserContext) (SessionContainer, error)
 	GetSessionInformation       *func(sessionHandle string, userContext supertokens.UserContext) (*SessionInformation, error)
 	RevokeAllSessionsForUser    *func(userID string, userContext supertokens.UserContext) ([]string, error)

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.0"
+const VERSION = "0.12.1"
 
 var (
 	cdiSupported = []string{"2.21"}


### PR DESCRIPTION
## Summary of change

- make loading access token from the request overrideable
- Made the access token string optional in the overrideable GetSession function
- Moved checking if the access token is nil into the overrideable GetSession function
- This is the golang equivalent of this PR in the node SDK: https://github.com/supertokens/supertokens-node/pull/562

## Related issues

- 

## Test Plan

All existing tests should pass

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
