### PR TITLE
feat: Add a helper function to read the original request from the user context inside overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.4] - 2023-05-23
+
+### Changes
+
+-   Added a new `GetRequestFromUserContext` function that can be used to read the original network request from the user context in overridden APIs and recipe functions
+
 ## [0.12.3] - 2023-05-22
 
 ### Added

--- a/recipe/emailpassword/userContext_test.go
+++ b/recipe/emailpassword/userContext_test.go
@@ -122,3 +122,101 @@ func TestDefaultUserContext(t *testing.T) {
 	assert.True(t, signInAPIContextWorks)
 	assert.True(t, createNewSessionContextWorks)
 }
+
+func TestGetRequestFromUserContext(t *testing.T) {
+	signInContextWorks := false
+	signInAPIContextWorks := false
+	createNewSessionContextWorks := false
+
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&epmodels.TypeInput{
+				Override: &epmodels.OverrideStruct{
+					Functions: func(originalImplementation epmodels.RecipeInterface) epmodels.RecipeInterface {
+						originalSignIn := *originalImplementation.SignIn
+						newSignIn := func(email string, password string, userContext supertokens.UserContext) (epmodels.SignInResponse, error) {
+							requestFromUserContext := supertokens.GetRequestFromUserContext(userContext)
+							if requestFromUserContext != nil {
+								assert.True(t, requestFromUserContext.Method == "POST")
+								assert.True(t, requestFromUserContext.RequestURI == "/auth/signin")
+								signInContextWorks = true
+							}
+							return originalSignIn(email, password, userContext)
+						}
+						*originalImplementation.SignIn = newSignIn
+						return originalImplementation
+					},
+
+					APIs: func(originalImplementation epmodels.APIInterface) epmodels.APIInterface {
+						originalSignInPOST := *originalImplementation.SignInPOST
+						newSignInPOST := func(formFields []epmodels.TypeFormField, options epmodels.APIOptions, userContext supertokens.UserContext) (epmodels.SignInPOSTResponse, error) {
+							requestFromUserContext := supertokens.GetRequestFromUserContext(userContext)
+							if requestFromUserContext != nil {
+								assert.True(t, requestFromUserContext.Method == "POST")
+								assert.True(t, requestFromUserContext.RequestURI == "/auth/signin")
+								signInAPIContextWorks = true
+							}
+							return originalSignInPOST(formFields, options, userContext)
+						}
+						*originalImplementation.SignInPOST = newSignInPOST
+						return originalImplementation
+					},
+				},
+			}),
+			session.Init(&sessmodels.TypeInput{
+				GetTokenTransferMethod: func(req *http.Request, forCreateNewSession bool, userContext supertokens.UserContext) sessmodels.TokenTransferMethod {
+					return sessmodels.CookieTransferMethod
+				},
+
+				Override: &sessmodels.OverrideStruct{
+					Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+						originalCreateNewSession := *originalImplementation.CreateNewSession
+						newCreateNewSession := func(userID string, accessTokenPayload map[string]interface{}, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+							requestFromUserContext := supertokens.GetRequestFromUserContext(userContext)
+							if requestFromUserContext != nil {
+								assert.True(t, requestFromUserContext.Method == "POST")
+								assert.True(t, requestFromUserContext.RequestURI == "/auth/signin" || requestFromUserContext.RequestURI == "/auth/signup")
+								createNewSessionContextWorks = true
+							}
+							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
+						}
+						*originalImplementation.CreateNewSession = newCreateNewSession
+						return originalImplementation
+					},
+				},
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	unittesting.SignupRequest("random@gmail.com", "validpass123", testServer.URL)
+
+	res1, err := unittesting.SignInRequest("random@gmail.com", "validpass123", testServer.URL)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, 200, res1.StatusCode)
+	assert.True(t, signInContextWorks)
+	assert.True(t, signInAPIContextWorks)
+	assert.True(t, createNewSessionContextWorks)
+}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.3"
+const VERSION = "0.12.4"
 
 var (
 	cdiSupported = []string{"2.21"}

--- a/supertokens/main.go
+++ b/supertokens/main.go
@@ -70,3 +70,7 @@ func GetUsersNewestFirst(paginationToken *string, limit *int, includeRecipeIds *
 func DeleteUser(userId string) error {
 	return deleteUser(userId)
 }
+
+func GetRequestFromUserContext(userContext UserContext) *http.Request {
+	return getRequestFromUserContext(userContext)
+}

--- a/supertokens/supertokens.go
+++ b/supertokens/supertokens.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -377,4 +378,24 @@ func ResetForTest() {
 
 func IsRunningInTestMode() bool {
 	return flag.Lookup("test.v") != nil || IsTestFlag
+}
+
+func getRequestFromUserContext(userContext UserContext) *http.Request {
+	if userContext == nil {
+		return nil
+	}
+
+	_userContext := *userContext
+	defaultObj, ok := _userContext["_default"]
+
+	if !ok {
+		return nil
+	}
+
+	emptyMap := map[string]interface{}{}
+	if reflect.TypeOf(defaultObj).Kind() != reflect.TypeOf(emptyMap).Kind() {
+		return nil
+	}
+
+	return defaultObj.(map[string]interface{})["request"].(*http.Request)
 }


### PR DESCRIPTION
## Summary of change

- Added a helper function exported by the SuperTokens class that makes it easier to get the original request from the user context
- This reduces the boilerplate of always having to use usercontext._default.request and also allows the request to be strongly typed

## Related issues

-   

## Test Plan

Added a test to make sure the new function works correctly

## Documentation changes
WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
