### PR TITLE
fix: Fix an issue where JWKs would be fetched multiple times a minute instead of once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.6] - 2023-06-01
+
+### Fixes
+
+- Fixes a bug in the session recipe where the SDK would try to fetch the JWKs from the core multiple times per minute
+
 ## [0.12.5] - 2023-05-26
 
 ### Fixes

--- a/recipe/session/accessToken.go
+++ b/recipe/session/accessToken.go
@@ -37,7 +37,7 @@ type AccessTokenInfoStruct struct {
 	TimeCreated             uint64
 }
 
-func GetInfoFromAccessToken(jwtInfo sessmodels.ParsedJWTInfo, jwks keyfunc.JWKS, doAntiCsrfCheck bool) (*AccessTokenInfoStruct, error) {
+func GetInfoFromAccessToken(jwtInfo sessmodels.ParsedJWTInfo, jwks *keyfunc.JWKS, doAntiCsrfCheck bool) (*AccessTokenInfoStruct, error) {
 	var payload map[string]interface{}
 
 	if jwtInfo.Version >= 3 {

--- a/recipe/session/recipeImplementation.go
+++ b/recipe/session/recipeImplementation.go
@@ -41,7 +41,7 @@ var protectedProps = []string{
 
 var JWKCacheMaxAgeInMs = 60000
 var JWKRefreshRateLimit = 500
-var jwksFunctions []sessmodels.GetJWKSResult
+var jwksResults []sessmodels.GetJWKSResult
 
 func getJWKS() []sessmodels.GetJWKSResult {
 	result := []sessmodels.GetJWKSResult{}
@@ -76,11 +76,11 @@ token verification. Otherwise, the result of session verification would depend o
 func GetCombinedJWKS() (*keyfunc.JWKS, error) {
 	var lastError error
 
-	if len(jwksFunctions) == 0 {
+	if len(jwksResults) == 0 {
 		return nil, defaultErrors.New("No SuperTokens core available to query. Please pass supertokens > connectionURI to the init function, or override all the functions of the recipe you are using.")
 	}
 
-	for _, jwk := range jwksFunctions {
+	for _, jwk := range jwksResults {
 		jwksResult := jwk.JWKS
 		err := jwk.Error
 
@@ -96,7 +96,7 @@ func GetCombinedJWKS() (*keyfunc.JWKS, error) {
 
 func MakeRecipeImplementation(querier supertokens.Querier, config sessmodels.TypeNormalisedInput, appInfo supertokens.NormalisedAppinfo) sessmodels.RecipeInterface {
 	var result sessmodels.RecipeInterface
-	jwksFunctions = getJWKS()
+	jwksResults = getJWKS()
 
 	createNewSession := func(userID string, accessTokenPayload map[string]interface{}, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
 		supertokens.LogDebugMessage("createNewSession: Started")

--- a/recipe/session/recipeImplementation.go
+++ b/recipe/session/recipeImplementation.go
@@ -20,11 +20,13 @@ import (
 	"encoding/json"
 	defaultErrors "errors"
 	"fmt"
+	"github.com/MicahParks/keyfunc"
 	"github.com/supertokens/supertokens-golang/recipe/session/claims"
 	"github.com/supertokens/supertokens-golang/recipe/session/errors"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
 	"reflect"
+	"time"
 )
 
 var protectedProps = []string{
@@ -37,8 +39,62 @@ var protectedProps = []string{
 	"antiCsrfToken",
 }
 
+var JWKCacheMaxAgeInMs = 60000
+var JWKRefreshRateLimit = 500
+var jwksFunctions []sessmodels.GetJWKSFunction
+
+func getJWKS() []sessmodels.GetJWKSFunction {
+	result := []sessmodels.GetJWKSFunction{}
+	corePaths := supertokens.GetAllCoreUrlsForPath("/.well-known/jwks.json")
+
+	for _, path := range corePaths {
+		result = append(result, func() (*keyfunc.JWKS, error) {
+			// RefreshUnknownKID - Fetch JWKS again if the kid in the header of the JWT does not match any in cache
+			// RefreshRateLimit - Only allow one re-fetch every 500 milliseconds
+			// RefreshInterval - Refreshes should occur every 600 seconds
+			jwks, err := keyfunc.Get(path, keyfunc.Options{
+				RefreshUnknownKID: true,
+				RefreshRateLimit:  time.Millisecond * time.Duration(JWKRefreshRateLimit),
+				RefreshInterval:   time.Millisecond * time.Duration(JWKCacheMaxAgeInMs),
+			})
+
+			return jwks, err
+		})
+	}
+
+	return result
+}
+
+/**
+This function fetches all JWKs from the first available core instance. This combines the other JWKS functions to become
+error resistant.
+
+Every core instance a backend is connected to is expected to connect to the same database and use the same key set for
+token verification. Otherwise, the result of session verification would depend on which core is currently available.
+*/
+func GetCombinedJWKS() (*keyfunc.JWKS, error) {
+	var lastError error
+
+	if len(jwksFunctions) == 0 {
+		return nil, defaultErrors.New("No SuperTokens core available to query. Please pass supertokens > connectionURI to the init function, or override all the functions of the recipe you are using.")
+	}
+
+	for _, jwk := range jwksFunctions {
+		jwksResult, err := jwk()
+
+		if err != nil {
+			lastError = err
+		} else {
+			return jwksResult, nil
+		}
+	}
+
+	return nil, lastError
+}
+
 func MakeRecipeImplementation(querier supertokens.Querier, config sessmodels.TypeNormalisedInput, appInfo supertokens.NormalisedAppinfo) sessmodels.RecipeInterface {
 	var result sessmodels.RecipeInterface
+	jwksFunctions = getJWKS()
 
 	createNewSession := func(userID string, accessTokenPayload map[string]interface{}, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
 		supertokens.LogDebugMessage("createNewSession: Started")

--- a/recipe/session/sessionFunctions.go
+++ b/recipe/session/sessionFunctions.go
@@ -70,7 +70,7 @@ func getSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens
 		}
 	}
 
-	accessTokenInfo, err = GetInfoFromAccessToken(parsedAccessToken, *combinedJwks, config.AntiCsrf == AntiCSRF_VIA_TOKEN && doAntiCsrfCheck)
+	accessTokenInfo, err = GetInfoFromAccessToken(parsedAccessToken, combinedJwks, config.AntiCsrf == AntiCSRF_VIA_TOKEN && doAntiCsrfCheck)
 	if err != nil {
 		if !defaultErrors.As(err, &errors.TryRefreshTokenError{}) {
 			supertokens.LogDebugMessage("getSessionHelper: Returning TryRefreshTokenError because GetInfoFromAccessToken returned an error")

--- a/recipe/session/sessionFunctions.go
+++ b/recipe/session/sessionFunctions.go
@@ -62,7 +62,7 @@ func createNewSessionHelper(config sessmodels.TypeNormalisedInput, querier super
 func getSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens.Querier, parsedAccessToken sessmodels.ParsedJWTInfo, antiCsrfToken *string, doAntiCsrfCheck, alwaysCheckCore bool) (sessmodels.GetSessionResponse, error) {
 	var accessTokenInfo *AccessTokenInfoStruct = nil
 	var err error = nil
-	combinedJwks, jwksError := sessmodels.GetCombinedJWKS()
+	combinedJwks, jwksError := GetCombinedJWKS()
 	if jwksError != nil {
 		supertokens.LogDebugMessage(fmt.Sprintf("getSessionHelper: Returning TryRefreshTokenError because there was an error fetching JWKs - %s", jwksError))
 		if !defaultErrors.As(jwksError, &errors.TryRefreshTokenError{}) {
@@ -95,7 +95,7 @@ func getSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens
 
 			// We check if the token was created since the last time we refreshed the keys from the core
 			// Since we do not know the exact timing of the last refresh, we check against the max age
-			if timeCreated <= (GetCurrTimeInMS() - uint64(sessmodels.JWKCacheMaxAgeInMs)) {
+			if timeCreated <= (GetCurrTimeInMS() - uint64(JWKCacheMaxAgeInMs)) {
 				return sessmodels.GetSessionResponse{}, err
 			}
 		} else {

--- a/recipe/session/sessmodels/models.go
+++ b/recipe/session/sessmodels/models.go
@@ -41,7 +41,10 @@ const (
 	AnyTransferMethod    TokenTransferMethod = "any"
 )
 
-type GetJWKSFunction = func() (*keyfunc.JWKS, error)
+type GetJWKSResult struct {
+	JWKS  *keyfunc.JWKS
+	Error error
+}
 
 func getCurrTimeInMS() uint64 {
 	return uint64(time.Now().UnixNano() / 1000000)

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.5"
+const VERSION = "0.12.6"
 
 var (
 	cdiSupported = []string{"2.21"}

--- a/test/unittesting/testingutils.go
+++ b/test/unittesting/testingutils.go
@@ -17,6 +17,7 @@
 package unittesting
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels"
@@ -817,4 +819,56 @@ func GetRequestWithJSONResult(url string, cookies []*http.Cookie) (int, map[stri
 	}
 	res.Body.Close()
 	return res.StatusCode, respObj, nil
+}
+
+type InfoLogData struct {
+	LastLine string
+	Output   []string
+}
+
+func GetInfoLogData(t *testing.T, startWith string) InfoLogData {
+	dir := getInstallationDir()
+	logFilePath := dir + "/logs/info.log"
+	file, err := os.Open(logFilePath)
+	if err != nil {
+		t.Fatalf("failed opening file: %s", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var lastLine string
+	var output []string
+
+	shouldRecordOutput := false
+
+	if startWith == "" {
+		shouldRecordOutput = true
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.TrimSpace(line) != "" {
+			if startWith != "" && strings.Contains(line, startWith) {
+				shouldRecordOutput = true
+				continue
+			}
+
+			if shouldRecordOutput {
+				output = append(output, line)
+			}
+
+			lastLine = line
+		}
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		t.Fatalf("scanner error: %s", err)
+	}
+
+	return InfoLogData{
+		LastLine: lastLine,
+		Output:   output,
+	}
 }


### PR DESCRIPTION
## Summary of change

- Refactors the logic of fetching JWKs from the core to make sure that the SDK only calls it once every minute
- Fixes an issue where GetInfoFromAccessToken would not accept a pointer to `keyfunc.JWKS` which would result in jwt verification failing even after the keys are refreshed for an unknown KID

## Related issues

-  

## Test Plan

Added tests to ensure that the fix works

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
