### PR TITLE
refactor: Refactor JWKs fetching logic for session recipe

### DIFF
--- a/recipe/session/recipeImplementation.go
+++ b/recipe/session/recipeImplementation.go
@@ -45,9 +45,18 @@ var JWKRefreshRateLimit = 500
 // Maintains a map of the core path to the result
 var jwksCache *sessmodels.GetJWKSResult = nil
 
-func getJWKS() []sessmodels.GetJWKSFunctionObject {
-	result := []sessmodels.GetJWKSFunctionObject{}
+func getJWKS() sessmodels.GetJWKSResult {
 	corePaths := supertokens.GetAllCoreUrlsForPath("/.well-known/jwks.json")
+
+	if len(corePaths) == 0 {
+		return sessmodels.GetJWKSResult{
+			JWKS:        nil,
+			Error:       defaultErrors.New("No SuperTokens core available to query. Please pass supertokens > connectionURI to the init function, or override all the functions of the recipe you are using."),
+			LastFetched: 0,
+		}
+	}
+
+	var lastError error
 
 	for _, path := range corePaths {
 		// Here we dont need to check if cached result had an error because we only add to cache
@@ -57,34 +66,24 @@ func getJWKS() []sessmodels.GetJWKSFunctionObject {
 			// We check if we need to refresh before returning
 			currentTime := time.Now().UnixNano() / int64(time.Millisecond)
 
-			// This means that the value in cache is not expired, in this case we return a function that simply
-			// returns the cached keys
+			// This means that the value in cache is not expired, in this case we return the cached value
 			//
 			// Note that this also means that the SDK will not try to query any other Core (if there are multiple)
-			// if it has even a single valid cache entry from one of the core URLs. It will only attempt to fetch
+			// if it has a valid cache entry from one of the core URLs. It will only attempt to fetch
 			// from the cores again after the entry in the cache is expired
 			if (currentTime - jwksCache.LastFetched) < JWKCacheMaxAgeInMs {
-				finalResult := []sessmodels.GetJWKSFunctionObject{}
+				if supertokens.IsRunningInTestMode() {
+					returnedFromCache = true
+				}
 
-				finalResult = append(finalResult, sessmodels.GetJWKSFunctionObject{
-					Fn: func(_ string) sessmodels.GetJWKSResult {
-						if supertokens.IsRunningInTestMode() {
-							returnedFromCache = true
-						}
-
-						return *jwksCache
-					},
-					Path: path,
-				})
-
-				return finalResult
+				return *jwksCache
 			}
 
 			// This means that the value in cache is expired, we clear from cache and proceed
 			// as if it was never cached because that would be the equivalent of refreshing
 			//
 			// This has the added benefit where if there are multiple cores [Core1, Core2] and initially
-			// Core1 was down (so the cache only has a result for Core2). When Core2's cache expires the SDK
+			// Core1 was down (so the cache only has the result from Core2). When the cache expires the SDK
 			// will try to re-fetch for Core1 and will return that result (and save to cache) if Core1 is now up
 			jwksCache = nil
 			if supertokens.IsRunningInTestMode() {
@@ -92,51 +91,46 @@ func getJWKS() []sessmodels.GetJWKSFunctionObject {
 			}
 		}
 
-		// We need to also save the path of the JWKS request and pass it to the function this way because
-		// golang only saves a reference to the last value set to path when this function actually is called
-		// so all the functions in the slice would end up calling the last core host
-		//
-		// Doing it this way makes sure that all individual hosts are called
-		result = append(result, sessmodels.GetJWKSFunctionObject{
-			Fn: func(inputPath string) sessmodels.GetJWKSResult {
-				if supertokens.IsRunningInTestMode() {
-					urlsAttemptedForJWKSFetch = append(urlsAttemptedForJWKSFetch, inputPath)
-				}
+		if supertokens.IsRunningInTestMode() {
+			urlsAttemptedForJWKSFetch = append(urlsAttemptedForJWKSFetch, path)
+		}
 
-				// RefreshUnknownKID - Fetch JWKS again if the kid in the header of the JWT does not match any in
-				// the keyfunc library's cache
-				jwks, err := keyfunc.Get(inputPath, keyfunc.Options{
-					RefreshUnknownKID: true,
-				})
-
-				jwksResult := sessmodels.GetJWKSResult{
-					JWKS:        jwks,
-					Error:       err,
-					LastFetched: time.Now().UnixNano() / int64(time.Millisecond),
-				}
-
-				// Dont add to cache if there is an error to keep the logic of checking cache simple
-				// This means that for multiple cores, the only item we add to cache would be the first
-				// core that returned keys without an error
-				//
-				// This also has the added benefit where if initially the request failed because the core
-				// was down and then it comes back up, the next time it will try to request that core again
-				// after the cache has expired
-				if err == nil {
-					jwksCache = &jwksResult
-				}
-
-				if supertokens.IsRunningInTestMode() {
-					returnedFromCache = false
-				}
-
-				return jwksResult
-			},
-			Path: path,
+		// RefreshUnknownKID - Fetch JWKS again if the kid in the header of the JWT does not match any in
+		// the keyfunc library's cache
+		jwks, jwksError := keyfunc.Get(path, keyfunc.Options{
+			RefreshUnknownKID: true,
 		})
+
+		if jwksError == nil {
+			jwksResult := sessmodels.GetJWKSResult{
+				JWKS:        jwks,
+				Error:       jwksError,
+				LastFetched: time.Now().UnixNano() / int64(time.Millisecond),
+			}
+
+			// Dont add to cache if there is an error to keep the logic of checking cache simple
+			//
+			// This also has the added benefit where if initially the request failed because the core
+			// was down and then it comes back up, the next time it will try to request that core again
+			// after the cache has expired
+			jwksCache = &jwksResult
+
+			if supertokens.IsRunningInTestMode() {
+				returnedFromCache = false
+			}
+
+			return jwksResult
+		}
+
+		lastError = jwksError
 	}
 
-	return result
+	// This means that fetching from all cores failed
+	return sessmodels.GetJWKSResult{
+		JWKS:        nil,
+		Error:       lastError,
+		LastFetched: 0,
+	}
 }
 
 /**
@@ -147,29 +141,17 @@ Every core instance a backend is connected to is expected to connect to the same
 token verification. Otherwise, the result of session verification would depend on which core is currently available.
 */
 func GetCombinedJWKS() (*keyfunc.JWKS, error) {
-	var lastError error
-	jwksObjects := getJWKS()
-
 	if supertokens.IsRunningInTestMode() {
 		urlsAttemptedForJWKSFetch = []string{}
 	}
 
-	if len(jwksObjects) == 0 {
-		return nil, defaultErrors.New("No SuperTokens core available to query. Please pass supertokens > connectionURI to the init function, or override all the functions of the recipe you are using.")
+	jwksResult := getJWKS()
+
+	if jwksResult.Error != nil {
+		return nil, jwksResult.Error
 	}
 
-	for _, jwkObject := range jwksObjects {
-		jwksResult := jwkObject.Fn(jwkObject.Path)
-		err := jwksResult.Error
-
-		if err != nil {
-			lastError = err
-		} else {
-			return jwksResult.JWKS, nil
-		}
-	}
-
-	return nil, lastError
+	return jwksResult.JWKS, nil
 }
 
 func MakeRecipeImplementation(querier supertokens.Querier, config sessmodels.TypeNormalisedInput, appInfo supertokens.NormalisedAppinfo) sessmodels.RecipeInterface {

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1256,7 +1256,7 @@ func TestThatJWKSIsFetchedAsExpected(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, len(wellKnownCallLogs), 1)
+	assert.Equal(t, len(wellKnownCallLogs), 0)
 
 	session, err := CreateNewSessionWithoutRequestResponse("rope", map[string]interface{}{}, map[string]interface{}{}, nil)
 
@@ -1282,7 +1282,7 @@ func TestThatJWKSIsFetchedAsExpected(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, len(wellKnownCallLogs), 2)
+	assert.Equal(t, len(wellKnownCallLogs), 1)
 
 	JWKRefreshRateLimit = originalRefreshlimit
 	JWKCacheMaxAgeInMs = originalCacheAge
@@ -1318,12 +1318,11 @@ func TestThatJWKSResultIsRefreshedProperly(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	jwksAfterStart := jwksResults
-	beforeKids := jwksAfterStart[0].JWKS.KIDs()
+	beforeKids := getJWKS()[0]().JWKS.KIDs()
 
 	time.Sleep(3 * time.Second)
 
-	afterKids := jwksAfterStart[0].JWKS.KIDs()
+	afterKids := getJWKS()[0]().JWKS.KIDs()
 	var newKeys []string
 
 	for _, key := range afterKids {
@@ -1371,7 +1370,7 @@ func TestThatJWKSAreRefreshedIfKIDIsUnkown(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, len(wellKnownCallLogs), 1)
+	assert.Equal(t, len(wellKnownCallLogs), 0)
 
 	session, err := CreateNewSessionWithoutRequestResponse("rope", map[string]interface{}{}, map[string]interface{}{}, nil)
 

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1335,13 +1335,23 @@ func TestThatJWKSResultIsRefreshedProperly(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	jwksBefore := getJWKS()
-	beforeKids := jwksBefore.JWKS.KIDs()
+	jwksBefore, err := getJWKS()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	beforeKids := jwksBefore.KIDs()
 
 	time.Sleep(3 * time.Second)
 
-	jwksAfter := getJWKS()
-	afterKids := jwksAfter.JWKS.KIDs()
+	jwksAfter, err := getJWKS()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	afterKids := jwksAfter.KIDs()
 	var newKeys []string
 
 	for _, key := range afterKids {
@@ -1562,7 +1572,6 @@ func TestJWKSCacheLogic(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, deleteFromCacheCount, 1)
 	assert.NotNil(t, jwksCache)
 
 	JWKRefreshRateLimit = originalRefreshlimit

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1335,13 +1335,13 @@ func TestThatJWKSResultIsRefreshedProperly(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	jwksBefore := getJWKS()[0]
-	beforeKids := jwksBefore.Fn(jwksBefore.Path).JWKS.KIDs()
+	jwksBefore := getJWKS()
+	beforeKids := jwksBefore.JWKS.KIDs()
 
 	time.Sleep(3 * time.Second)
 
-	jwksAfter := getJWKS()[0]
-	afterKids := jwksAfter.Fn(jwksAfter.Path).JWKS.KIDs()
+	jwksAfter := getJWKS()
+	afterKids := jwksAfter.JWKS.KIDs()
 	var newKeys []string
 
 	for _, key := range afterKids {

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1539,7 +1539,7 @@ func TestJWKSCacheLogic(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, len(jwksCache), 0)
+	assert.Nil(t, jwksCache)
 
 	session, err := CreateNewSessionWithoutRequestResponse("rope", map[string]interface{}{}, map[string]interface{}{}, nil)
 
@@ -1547,7 +1547,7 @@ func TestJWKSCacheLogic(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, len(jwksCache), 0)
+	assert.Nil(t, jwksCache)
 
 	tokens := session.GetAllSessionTokensDangerously()
 	session, err = GetSessionWithoutRequestResponse(tokens.AccessToken, tokens.AntiCsrfToken, &sessmodels.VerifySessionOptions{})
@@ -1556,7 +1556,7 @@ func TestJWKSCacheLogic(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, len(jwksCache), 1)
+	assert.NotNil(t, jwksCache)
 
 	time.Sleep(3 * time.Second)
 
@@ -1566,7 +1566,7 @@ func TestJWKSCacheLogic(t *testing.T) {
 	}
 
 	assert.Equal(t, deleteFromCacheCount, 1)
-	assert.Equal(t, len(jwksCache), 1)
+	assert.NotNil(t, jwksCache)
 
 	JWKRefreshRateLimit = originalRefreshlimit
 	JWKCacheMaxAgeInMs = originalCacheAge
@@ -1745,7 +1745,7 @@ func TestThatJWKSReturnsFromCacheCorrectly(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, len(jwksCache), 0)
+	assert.Nil(t, jwksCache)
 
 	tokens := session.GetAllSessionTokensDangerously()
 	session, err = GetSessionWithoutRequestResponse(tokens.AccessToken, tokens.AntiCsrfToken, &sessmodels.VerifySessionOptions{})

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1437,6 +1437,30 @@ func TestThatJWKSAreRefreshedIfKIDIsUnkown(t *testing.T) {
 	assert.Equal(t, len(wellKnownCallLogs), 2)
 }
 
+func TestThatInvalidConnectionUriDoesNotThrowDuringInitForJWKS(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "https://try.supertokens.io:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+	BeforeEach()
+	unittesting.SetKeyValueInConfig("access_token_dynamic_signing_key_update_interval", "0.0014")
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
 type MockResponseWriter struct{}
 
 func (mw MockResponseWriter) Header() http.Header {

--- a/recipe/session/sessmodels/models.go
+++ b/recipe/session/sessmodels/models.go
@@ -47,7 +47,12 @@ type GetJWKSResult struct {
 	LastFetched int64
 }
 
-type GetJWKSFunction = func() GetJWKSResult
+type GetJWKSFunctionObject struct {
+	Fn   GetJWKSFunction
+	Path string
+}
+
+type GetJWKSFunction = func(string) GetJWKSResult
 
 func getCurrTimeInMS() uint64 {
 	return uint64(time.Now().UnixNano() / 1000000)

--- a/recipe/session/sessmodels/models.go
+++ b/recipe/session/sessmodels/models.go
@@ -42,9 +42,12 @@ const (
 )
 
 type GetJWKSResult struct {
-	JWKS  *keyfunc.JWKS
-	Error error
+	JWKS        *keyfunc.JWKS
+	Error       error
+	LastFetched int64
 }
+
+type GetJWKSFunction = func() GetJWKSResult
 
 func getCurrTimeInMS() uint64 {
 	return uint64(time.Now().UnixNano() / 1000000)

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -24,7 +24,6 @@ import (
 
 // Testing constants
 var didGetSessionCallCore = false
-var deleteFromCacheCount = 0
 var returnedFromCache = false
 var urlsAttemptedForJWKSFetch []string
 
@@ -32,7 +31,6 @@ func resetAll() {
 	supertokens.ResetForTest()
 	ResetForTest()
 	didGetSessionCallCore = false
-	deleteFromCacheCount = 0
 	returnedFromCache = false
 	urlsAttemptedForJWKSFetch = []string{}
 	jwksCache = nil

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -24,11 +24,17 @@ import (
 
 // Testing constants
 var didGetSessionCallCore = false
+var deleteFromCacheCount = 0
+var returnedFromCache = false
+var urlsAttemptedForJWKSFetch []string
 
 func resetAll() {
 	supertokens.ResetForTest()
 	ResetForTest()
 	didGetSessionCallCore = false
+	deleteFromCacheCount = 0
+	returnedFromCache = false
+	urlsAttemptedForJWKSFetch = []string{}
 }
 
 func BeforeEach() {

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -16,6 +16,7 @@
 package session
 
 import (
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"net/http"
 
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -35,6 +36,7 @@ func resetAll() {
 	deleteFromCacheCount = 0
 	returnedFromCache = false
 	urlsAttemptedForJWKSFetch = []string{}
+	jwksCache = map[string]sessmodels.GetJWKSResult{}
 }
 
 func BeforeEach() {

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -16,7 +16,6 @@
 package session
 
 import (
-	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"net/http"
 
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -36,7 +35,7 @@ func resetAll() {
 	deleteFromCacheCount = 0
 	returnedFromCache = false
 	urlsAttemptedForJWKSFetch = []string{}
-	jwksCache = map[string]sessmodels.GetJWKSResult{}
+	jwksCache = nil
 }
 
 func BeforeEach() {

--- a/recipe/session/testingUtils.go
+++ b/recipe/session/testingUtils.go
@@ -29,11 +29,6 @@ func resetAll() {
 	supertokens.ResetForTest()
 	ResetForTest()
 	didGetSessionCallCore = false
-	for _, jwks := range jwksResults {
-		if jwks.JWKS != nil {
-			jwks.JWKS.EndBackground()
-		}
-	}
 }
 
 func BeforeEach() {


### PR DESCRIPTION
## Summary of change

- Refactors the JWKS fetching logic to:
    - Not fetch JWKs on init
    - Use a in memory cache for re-fetching instead of using keyfuncs background requests
    - To stop fetching JWKs from cores after a valid response is received

- Adds additional tests to verify the JWKS behaviour (and adds comments explaining what the tests are meant to do)
- Adds code comments explaining the logic of the JWKS fetching setup

## Related issues
- 

## Test Plan
Added new tests + all existing tests should pass

## Documentation changes
NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
