### PR TITLE
fix: Fix access token verification logic to use latest version if the JWT header has no version in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.7] - 2023-06-05
+
+### Fixes
+
+- Fixes an issue where session verification would fail when using JWTs created by the JWT recipe (and not the session recipe)
+
 ## [0.12.6] - 2023-06-01
 
 ### Fixes

--- a/recipe/session/jwt.go
+++ b/recipe/session/jwt.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"reflect"
@@ -42,6 +43,7 @@ func checkHeader(header string) error {
 
 func ParseJWTWithoutSignatureVerification(token string) (sessmodels.ParsedJWTInfo, error) {
 	splittedInput := strings.Split(token, ".")
+	latestAccessTokenVersion := 3
 	var kid *string
 	if len(splittedInput) != 3 {
 		errors.New("Invalid JWT")
@@ -65,7 +67,7 @@ func ParseJWTWithoutSignatureVerification(token string) (sessmodels.ParsedJWTInf
 		versionInHeader, ok := parsedHeader["version"]
 
 		if !ok {
-			return sessmodels.ParsedJWTInfo{}, errors.New("JWT header mismatch")
+			versionInHeader = fmt.Sprint(latestAccessTokenVersion)
 		}
 
 		if reflect.TypeOf(versionInHeader).Kind() != reflect.String {
@@ -87,7 +89,7 @@ func ParseJWTWithoutSignatureVerification(token string) (sessmodels.ParsedJWTInf
 		kidString := kidInHeader.(string)
 		kid = &kidString
 
-		if parsedHeader["typ"].(string) != "JWT" || parseError != nil || versionNumber < 3 || parsedHeader["kid"] == nil {
+		if parsedHeader["typ"].(string) != "JWT" || parseError != nil || versionNumber < latestAccessTokenVersion || parsedHeader["kid"] == nil {
 			return sessmodels.ParsedJWTInfo{}, errors.New("JWT header mismatch")
 		}
 

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1907,6 +1908,115 @@ func TestSessionVerificationOfJWTBasedOnSessionPayloadWithCheckDatabase(t *testi
 	}
 
 	assert.Equal(t, session.GetUserID(), "testing")
+}
+
+func TestThatLockingForJWKSCacheWorksFine(t *testing.T) {
+	originalRefreshlimit := JWKRefreshRateLimit
+	originalCacheAge := JWKCacheMaxAgeInMs
+
+	JWKRefreshRateLimit = 100
+	JWKCacheMaxAgeInMs = 2000
+
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+	BeforeEach()
+	unittesting.SetKeyValueInConfig("access_token_dynamic_signing_key_update_interval", "0.0014")
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	differentKeyFoundCount := 0
+	notReturnFromCacheCount := 0
+	keys := []string{}
+	shouldStop := false
+
+	jwks, err := GetCombinedJWKS()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	for _, k := range jwks.KIDs() {
+		keys = append(keys, k)
+	}
+
+	go func() {
+		time.Sleep(11 * time.Second)
+		shouldStop = true
+	}()
+
+	threadCount := 10
+	var wg sync.WaitGroup
+	wg.Add(threadCount)
+
+	for i := 0; i < threadCount; i++ {
+		go jwksLockTestRoutine(t, &shouldStop, i, &wg, func(_keys []string) {
+			if returnedFromCache == false {
+				notReturnFromCacheCount++
+			}
+
+			newKeys := []string{}
+
+			for _, _k2 := range _keys {
+				if !supertokens.DoesSliceContainString(_k2, keys) {
+					newKeys = append(newKeys, _k2)
+				}
+			}
+
+			if len(newKeys) != 0 {
+				differentKeyFoundCount++
+				keys = _keys
+			}
+		})
+	}
+
+	wg.Wait()
+
+	// We test for both
+	// - The keys changing
+	// - The number of times the result is not returned from cache
+	//
+	// Because even if the keys change only twice it could still mean that the SDK's cache locking
+	// does not work correctly and that it tried to query the core more times than it should have
+	//
+	// Checking for both the key change count and the cache miss count verifies the locking behaviour properly
+	//
+	// With the signing key interval as 5 seconds, and the test making requests for 11 seconds
+	// You expect the keys to change twice
+	assert.Equal(t, differentKeyFoundCount, 2)
+	// With cache lifetime as 2 seconds, you expect the cache to miss 5 times
+	assert.Equal(t, notReturnFromCacheCount, 5)
+
+	JWKRefreshRateLimit = originalRefreshlimit
+	JWKCacheMaxAgeInMs = originalCacheAge
+}
+
+func jwksLockTestRoutine(t *testing.T, shouldStop *bool, index int, group *sync.WaitGroup, doPost func([]string)) {
+	jwks, err := GetCombinedJWKS()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	doPost(jwks.KIDs())
+	time.Sleep(100 * time.Millisecond)
+	if *shouldStop == false {
+		jwksLockTestRoutine(t, shouldStop, index, group, doPost)
+	} else {
+		group.Done()
+	}
 }
 
 type MockResponseWriter struct{}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.6"
+const VERSION = "0.12.7"
 
 var (
 	cdiSupported = []string{"2.21"}


### PR DESCRIPTION
## Summary of change

- Refactors JWT parsing logic to assume latest access token version if the provided access token's header does not contain a version
- Adds a test to verify the above change
- Adds a test to make sure that only the access token is sent to the frontend if expose to frontend is set to true
- Adds a test to make sure JWKs locking works fine

## Related issues

- 

## Test Plan

Adds tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
