### PR TITLE
feat: Allow users to set dashboard users as admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.8] - 2023-06-08
+
+### Added
+
+-   The Dashboard recipe now accepts a new `Admins` property which can be used to give Dashboard Users write privileges for the user dashboard.
+
+### Changes
+
+-   Dashboard APIs now return a status code `403` for all non-GET requests if the currently logged in Dashboard User is not listed in the `Admins` array
+
 ## [0.12.7] - 2023-06-05
 
 ### Fixes

--- a/recipe/dashboard/apiKeyProtector.go
+++ b/recipe/dashboard/apiKeyProtector.go
@@ -1,13 +1,22 @@
 package dashboard
 
 import (
+	defaultErrors "errors"
 	"github.com/supertokens/supertokens-golang/recipe/dashboard/dashboardmodels"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard/errors"
 	"github.com/supertokens/supertokens-golang/supertokens"
 )
 
 func apiKeyProtector(apiImpl dashboardmodels.APIInterface, options dashboardmodels.APIOptions, userContext supertokens.UserContext, call func() (interface{}, error)) error {
 	shouldAllowAccess, err := (*options.RecipeImplementation.ShouldAllowAccess)(options.Req, options.Config, userContext)
 	if err != nil {
+		if defaultErrors.As(err, &errors.OperationNotAllowedError{}) {
+			body := map[string]string{
+				"message": err.Error(),
+			}
+			return supertokens.Send403Response(options.Res, body)
+		}
+
 		return err
 	}
 

--- a/recipe/dashboard/dashboardmodels/models.go
+++ b/recipe/dashboard/dashboardmodels/models.go
@@ -17,6 +17,7 @@ package dashboardmodels
 
 type TypeInput struct {
 	ApiKey   string
+	Admins   *[]string
 	Override *OverrideStruct
 }
 
@@ -29,6 +30,7 @@ const (
 
 type TypeNormalisedInput struct {
 	ApiKey   string
+	Admins   []string
 	AuthMode TypeAuthMode
 	Override OverrideStruct
 }

--- a/recipe/dashboard/errors/errors.go
+++ b/recipe/dashboard/errors/errors.go
@@ -1,0 +1,13 @@
+package errors
+
+type OperationNotAllowedError struct {
+	Msg string
+}
+
+func (err OperationNotAllowedError) Error() string {
+	if err.Msg == "" {
+		return "You are not permitted to perform this operation"
+	}
+
+	return err.Msg
+}

--- a/recipe/dashboard/utils.go
+++ b/recipe/dashboard/utils.go
@@ -31,10 +31,25 @@ func validateAndNormaliseUserInput(appInfo supertokens.NormalisedAppinfo, config
 		_config = *config
 	}
 
+	if _config.ApiKey != "" && _config.Admins != nil {
+		supertokens.LogDebugMessage("User Dashboard: Providing 'Admins' has no effect when using an apiKey.")
+	}
+
 	if _config.ApiKey != "" {
 		typeNormalisedInput.ApiKey = _config.ApiKey
 		typeNormalisedInput.AuthMode = dashboardmodels.AuthModeAPIKey
 	}
+
+	_admins := []string{}
+	if _config.Admins != nil {
+		providedAdmins := *_config.Admins
+
+		for _, email := range providedAdmins {
+			_admins = append(_admins, normaliseEmail(email))
+		}
+	}
+
+	typeNormalisedInput.Admins = _admins
 
 	if _config.Override != nil {
 		if _config.Override.Functions != nil {
@@ -150,4 +165,11 @@ func getApiIdIfMatched(path supertokens.NormalisedURLPath, method string) (*stri
 	}
 
 	return nil, nil
+}
+
+func normaliseEmail(email string) string {
+	email = strings.TrimSpace(email)
+	email = strings.ToLower(email)
+
+	return email
 }

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.7"
+const VERSION = "0.12.8"
 
 var (
 	cdiSupported = []string{"2.21"}

--- a/supertokens/utils.go
+++ b/supertokens/utils.go
@@ -171,6 +171,21 @@ func Send200Response(res http.ResponseWriter, responseJson interface{}) error {
 	return nil
 }
 
+func Send403Response(res http.ResponseWriter, responseJson interface{}) error {
+	dw := MakeDoneWriter(res)
+	if !dw.IsDone() {
+		res.Header().Set("Content-Type", "application/json; charset=utf-8")
+		res.WriteHeader(403)
+		bytes, err := json.Marshal(responseJson)
+		if err != nil {
+			return err
+		} else {
+			res.Write(bytes)
+		}
+	}
+	return nil
+}
+
 func SendHTMLResponse(res http.ResponseWriter, statusCode int, htmlString string) error {
 	LogDebugMessage(fmt.Sprintf("Sending HTML response to client with status code: %d", statusCode))
 	dw := MakeDoneWriter(res)


### PR DESCRIPTION
## Summary of change

- Allows users to pass emails that are treated as admins
- Only admins can perform write/delete operations
- All other users can perform read operations

## Related issues

-   ...

## Test Plan


## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
