### PR TITLE
refactor: Update specific test to nor run on CDI version below 2.21

### DIFF
--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1890,7 +1890,8 @@ func TestSessionVerificationOfJWTBasedOnSessionPayloadWithCheckDatabase(t *testi
 		t.Fail()
 	}
 
-	if supertokens.MaxVersion(cdiVersion, "2.21") != cdiVersion {
+	// Only run test for cdi > 2.21 (not greater than equal to)
+	if supertokens.MaxVersion(cdiVersion, "2.21") == "2.21" {
 		t.Skip()
 	}
 

--- a/recipe/session/session_test.go
+++ b/recipe/session/session_test.go
@@ -1881,6 +1881,19 @@ func TestSessionVerificationOfJWTBasedOnSessionPayloadWithCheckDatabase(t *testi
 		t.Error(err.Error())
 	}
 
+	querier, err := supertokens.GetNewQuerierInstanceOrThrowError("session")
+	if err != nil {
+		t.Fail()
+	}
+	cdiVersion, err := querier.GetQuerierAPIVersion()
+	if err != nil {
+		t.Fail()
+	}
+
+	if supertokens.MaxVersion(cdiVersion, "2.21") != cdiVersion {
+		t.Skip()
+	}
+
 	session, err := CreateNewSessionWithoutRequestResponse("testing", map[string]interface{}{}, map[string]interface{}{}, nil)
 	if err != nil {
 		t.Error(err.Error())


### PR DESCRIPTION
## Summary of change

Updates tests to run certain tests for specific CDI versions or above

## Related issues

- ...

## Test Plan

## Documentation changes

NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
