### PR TITLE
docs: fix migration guide in changelog to be consistent with node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,12 +107,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### If you used the jwt feature of the session recipe
 
 1. Add `ExposeAccessTokenToFrontendInCookieBasedAuth: true` to the Session recipe config on the backend if you need to access the JWT on the frontend.
-2. On the frontend where you accessed the JWT before by: `(await Session.getAccessTokenPayloadSecurely()).jwt` update to:
+2. Choose a prop from the following list. We'll use `sub` in the code below, but you can replace it with another from the list if you used it in a custom access token payload.
+    - `sub`
+    - `iat`
+    - `exp`
+    - `sessionHandle`
+3. On the frontend where you accessed the JWT before by: `(await Session.getAccessTokenPayloadSecurely()).jwt` update to:
 
 ```tsx
 let jwt = null;
 const accessTokenPayload = await Session.getAccessTokenPayloadSecurely();
-if (accessTokenPayload.jwt === undefined) {
+if (accessTokenPayload.sub !== undefined) {
     jwt = await Session.getAccessToken();
 } else {
     // This branch is only required if there are valid access tokens created before the update
@@ -121,12 +126,12 @@ if (accessTokenPayload.jwt === undefined) {
 }
 ```
 
-3. On the backend if you accessed the JWT before by `session.GetAccessTokenPayload()["jwt"]` please update to:
+4. On the backend if you accessed the JWT before by `session.GetAccessTokenPayload()["jwt"]` please update to:
 
 ```go
 var jwt string
 accessTokenPayload := session.GetAccessTokenPayload();
-if (accessTokenPayload["jwt"] == nil) {
+if (accessTokenPayload["sub"] != nil) {
     jwt =  session.GetAccessToken();
 } else {
     // This branch is only required if there are valid access tokens created before the update


### PR DESCRIPTION
## Summary of change

update/fix migration guide in changelog

## Related issues

- https://github.com/supertokens/supertokens-node/pull/603
- https://github.com/supertokens/supertokens-node/pull/601

## Test Plan

N/A Docs only change

## Documentation changes

N/A Docs only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
