### PR TITLE
chore: Add additional tests for session verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Adds additional tests for session verification
+
 ## [0.12.7] - 2023-06-05
 
 ### Fixes


### PR DESCRIPTION
## Summary of change

- Adds a test to make sure session verification fails if the session was created with static signing keys but the current config is set to use dynamic signing keys
- Adds a test to make sure session verification does not fail if session required was false and no access token was passed

## Related issues

- 

## Test Plan

Adds new tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
