### PR TITLE
fix: properly ignoring anti-csrf in optional session validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.8] - 2023-07-10
+
 - Adds additional tests for session verification
+
+### Fixes
+
+- Now properly ignoring missing anti-csrf tokens in optional session validation
 
 ## [0.12.7] - 2023-06-05
 

--- a/recipe/session/sessionRequestFunctions.go
+++ b/recipe/session/sessionRequestFunctions.go
@@ -179,8 +179,12 @@ func GetSessionFromRequest(req *http.Request, res http.ResponseWriter, config se
 		doAntiCsrfCheck = &doAntiCsrfCheckBool
 	}
 
+	False := false
 	if requestTokenTransferMethod != nil && *requestTokenTransferMethod == sessmodels.HeaderTransferMethod {
-		False := false
+		doAntiCsrfCheck = &False
+	}
+
+	if accessToken == nil {
 		doAntiCsrfCheck = &False
 	}
 

--- a/recipe/session/verifySession_test.go
+++ b/recipe/session/verifySession_test.go
@@ -968,7 +968,7 @@ func TestThatAntiCSRFCheckIsSkippedIfSessionRequiredIsFalseAndNoAccessTokenIsPas
 	res, err := http.DefaultClient.Do(req)
 	assert.Equal(t, res.StatusCode, 401)
 
-	req, err = http.NewRequest(http.MethodGet, app.URL+"/verify-optional", nil)
+	req, err = http.NewRequest(http.MethodPost, app.URL+"/verify-optional", nil)
 	assert.NoError(t, err)
 
 	res, err = http.DefaultClient.Do(req)

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.7"
+const VERSION = "0.12.8"
 
 var (
 	cdiSupported = []string{"2.21"}


### PR DESCRIPTION
## Summary of change

- Adds additional tests for session verification
- Now properly ignoring missing anti-csrf tokens in optional session validation

## Related issues

- 

## Test Plan

Adds new tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
