### PR TITLE
fix: Fix issue with dashboard throwing an error when updating the user's password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.9] - 2023-07-26
+
+- Fixes an issue where updating the user's password from the user management dashboard would result in a crash when using the thirdpartyemailpassword recipe (https://github.com/supertokens/supertokens-golang/issues/311)
+
 ## [0.12.8] - 2023-07-10
 
 - Adds additional tests for session verification

--- a/recipe/dashboard/api/userdetails/userPasswordPut.go
+++ b/recipe/dashboard/api/userdetails/userPasswordPut.go
@@ -126,9 +126,9 @@ func UserPasswordPut(apiInterface dashboardmodels.APIInterface, options dashboar
 		}, nil
 	}
 
-	var passwordField epmodels.TypeInputFormField
+	var passwordField epmodels.NormalisedFormField
 
-	for _, value := range thirdpartyemailpassword.GetRecipeInstance().Config.SignUpFeature.FormFields {
+	for _, value := range thirdpartyemailpassword.GetRecipeInstance().GetEmailPasswordRecipe().Config.SignUpFeature.FormFields {
 		if value.ID == "password" {
 			passwordField = value
 		}

--- a/recipe/dashboard/api/userdetails/userPut.go
+++ b/recipe/dashboard/api/userdetails/userPut.go
@@ -96,9 +96,9 @@ func updateEmailForRecipeId(recipeId string, userId string, email string) (updat
 	}
 
 	if recipeId == "thirdpartyemailpassword" {
-		var emailField epmodels.TypeInputFormField
+		var emailField epmodels.NormalisedFormField
 
-		for _, value := range thirdpartyemailpassword.GetRecipeInstance().Config.SignUpFeature.FormFields {
+		for _, value := range thirdpartyemailpassword.GetRecipeInstance().GetEmailPasswordRecipe().Config.SignUpFeature.FormFields {
 			if value.ID == "email" {
 				emailField = value
 			}

--- a/recipe/dashboard/userPasswordPut_test.go
+++ b/recipe/dashboard/userPasswordPut_test.go
@@ -1,0 +1,88 @@
+package dashboard
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard/dashboardmodels"
+	"github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+/**
+- Initialise with thirdpartyemailpassword and provide no custom form fields
+- Create an emailpassword user using the thirdpartyemailpassword recipe
+- Try to change the password of the user
+- Should result in no errors
+- Sign in with new password
+- Should result in no errors and same user should be returned
+*/
+func TestThatUpdatingPasswordWithNoSignUpFeatureInTPEPWorks(t *testing.T) {
+	config := supertokens.TypeInput{
+		OnSuperTokensAPIError: func(err error, req *http.Request, res http.ResponseWriter) {
+			print(err)
+		},
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			thirdpartyemailpassword.Init(nil),
+			Init(&dashboardmodels.TypeInput{
+				ApiKey: "testapikey",
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(config)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	signupResponse, err := thirdpartyemailpassword.EmailPasswordSignUp("testing@supertokens.com", "abcd1234")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.NotNil(t, signupResponse.OK)
+
+	userId := signupResponse.OK.User.ID
+
+	req, err := http.NewRequest(http.MethodPut, testServer.URL+"/auth/dashboard/api/user/password", strings.NewReader(`{"userId": "`+userId+`", "newPassword": "newabcd1234"}`))
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	req.Header.Set("Authorization", "Bearer testapikey")
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	signInResponse, err := thirdpartyemailpassword.EmailPasswordSignIn("testing@supertokens.com", "newabcd1234")
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.NotNil(t, signInResponse.OK)
+	assert.Equal(t, signInResponse.OK.User.ID, userId)
+}

--- a/recipe/dashboard/userPut_test.go
+++ b/recipe/dashboard/userPut_test.go
@@ -1,0 +1,88 @@
+package dashboard
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard/dashboardmodels"
+	"github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+/**
+- Initialise with thirdpartyemailpassword and provide no custom form fields
+- Create an emailpassword user using the thirdpartyemailpassword recipe
+- Try to change the password of the user
+- Should result in no errors
+- Sign in with new password
+- Should result in no errors and same user should be returned
+*/
+func TestThatUpdatingEmailWithNoSignUpFeatureInTPEPWorks(t *testing.T) {
+	config := supertokens.TypeInput{
+		OnSuperTokensAPIError: func(err error, req *http.Request, res http.ResponseWriter) {
+			print(err)
+		},
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			thirdpartyemailpassword.Init(nil),
+			Init(&dashboardmodels.TypeInput{
+				ApiKey: "testapikey",
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(config)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	signupResponse, err := thirdpartyemailpassword.EmailPasswordSignUp("testing@supertokens.com", "abcd1234")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.NotNil(t, signupResponse.OK)
+
+	userId := signupResponse.OK.User.ID
+
+	req, err := http.NewRequest(http.MethodPut, testServer.URL+"/auth/dashboard/api/user", strings.NewReader(`{"userId": "`+userId+`", "firstName": "", "lastName": "", "phone": "", "email": "testing2@supertokens.com", "recipeId": "emailpassword"}`))
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	req.Header.Set("Authorization", "Bearer testapikey")
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	signInResponse, err := thirdpartyemailpassword.EmailPasswordSignIn("testing2@supertokens.com", "abcd1234")
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.NotNil(t, signInResponse.OK)
+	assert.Equal(t, signInResponse.OK.User.ID, userId)
+}

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -101,6 +101,10 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config *
 		r.emailPasswordRecipe = emailPasswordInstance
 	}
 
+	r.GetEmailPasswordRecipe = func() *emailpassword.Recipe {
+		return r.emailPasswordRecipe
+	}
+
 	if len(verifiedConfig.Providers) > 0 {
 		if thirdPartyInstance == nil {
 			thirdPartyConfig := &tpmodels.TypeInput{
@@ -216,8 +220,4 @@ func (r *Recipe) handleError(err error, req *http.Request, res http.ResponseWrit
 
 func ResetForTest() {
 	singletonInstance = nil
-}
-
-func GetEmailPasswordRecipe(r *Recipe) *emailpassword.Recipe {
-	return r.emailPasswordRecipe
 }

--- a/recipe/thirdpartyemailpassword/recipe.go
+++ b/recipe/thirdpartyemailpassword/recipe.go
@@ -34,13 +34,14 @@ import (
 const RECIPE_ID = "thirdpartyemailpassword"
 
 type Recipe struct {
-	RecipeModule        supertokens.RecipeModule
-	Config              tpepmodels.TypeNormalisedInput
-	emailPasswordRecipe *emailpassword.Recipe
-	thirdPartyRecipe    *thirdparty.Recipe
-	RecipeImpl          tpepmodels.RecipeInterface
-	APIImpl             tpepmodels.APIInterface
-	EmailDelivery       emaildelivery.Ingredient
+	RecipeModule           supertokens.RecipeModule
+	Config                 tpepmodels.TypeNormalisedInput
+	emailPasswordRecipe    *emailpassword.Recipe
+	thirdPartyRecipe       *thirdparty.Recipe
+	RecipeImpl             tpepmodels.RecipeInterface
+	APIImpl                tpepmodels.APIInterface
+	EmailDelivery          emaildelivery.Ingredient
+	GetEmailPasswordRecipe func() *emailpassword.Recipe
 }
 
 var singletonInstance *Recipe
@@ -215,4 +216,8 @@ func (r *Recipe) handleError(err error, req *http.Request, res http.ResponseWrit
 
 func ResetForTest() {
 	singletonInstance = nil
+}
+
+func GetEmailPasswordRecipe(r *Recipe) *emailpassword.Recipe {
+	return r.emailPasswordRecipe
 }

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.12.8"
+const VERSION = "0.12.9"
 
 var (
 	cdiSupported = []string{"2.21"}


### PR DESCRIPTION
## Summary of change

- Fixes an issue where updating a user's password from the dashboard would result in a pointer exception when using the thirdpartyemailpassword recipe (Also applied the fix when updating the user's email)
- Adds tests for userPasswordPut and userPut APIs to verify the fix

## Related issues

- https://github.com/supertokens/supertokens-golang/issues/311

## Test Plan

Added new tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
