### PR TITLE
chore: Add test for access token validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,8 @@
 -   [ ] Issue this PR against the latest non released version branch.
     -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
     -   If no such branch exists, then create one from the latest released branch.
+-   [ ] If access token structure has changed
+    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 
 
 ## Remaining TODOs for this PR
 

--- a/recipe/session/accessTokenVersions_test.go
+++ b/recipe/session/accessTokenVersions_test.go
@@ -999,3 +999,70 @@ func TestShouldThrowWhenRefreshInLegacySessionsWithProtectedProp(t *testing.T) {
 	assert.True(t, cookiesAfterRefresh["refreshTokenFromAny"] == "")
 	assert.True(t, cookiesAfterRefresh["frontToken"] == "remove")
 }
+
+/**
+We want to make sure that for access token claims that can be null, the SDK does not fail access token validation if the
+core does not send them as part of the payload.
+
+For this we verify that validation passes when the keys are nil, empty or a different type
+
+For now this test checks for:
+- antiCsrfToken
+- parentRefreshTokenHash1
+
+But this test should be updated to include any keys that the core considers optional in the payload (i.e either it sends
+JSON null or skips them entirely)
+*/
+func TestValidationLogicWithKeysThatCanUseJSONNullValuesInClaims(t *testing.T) {
+	version3 := 3
+
+	payloadv3 := map[string]interface{}{
+		"sessionHandle":     "",
+		"sub":               "",
+		"refreshTokenHash1": "",
+		"exp":               float64(0),
+		"iat":               float64(0),
+	}
+
+	err := ValidateAccessTokenStructure(payloadv3, version3)
+	assert.NoError(t, err)
+
+	payloadv3 = map[string]interface{}{
+		"sessionHandle":           "",
+		"sub":                     "",
+		"refreshTokenHash1":       "",
+		"exp":                     float64(0),
+		"iat":                     float64(0),
+		"parentRefreshTokenHash1": nil,
+		"antiCsrfToken":           nil,
+	}
+
+	err = ValidateAccessTokenStructure(payloadv3, version3)
+	assert.NoError(t, err)
+
+	payloadv3 = map[string]interface{}{
+		"sessionHandle":           "",
+		"sub":                     "",
+		"refreshTokenHash1":       "",
+		"exp":                     float64(0),
+		"iat":                     float64(0),
+		"parentRefreshTokenHash1": "",
+		"antiCsrfToken":           "",
+	}
+
+	err = ValidateAccessTokenStructure(payloadv3, version3)
+	assert.NoError(t, err)
+
+	payloadv3 = map[string]interface{}{
+		"sessionHandle":           "",
+		"sub":                     "",
+		"refreshTokenHash1":       "",
+		"exp":                     float64(0),
+		"iat":                     float64(0),
+		"parentRefreshTokenHash1": 1,
+		"antiCsrfToken":           1,
+	}
+
+	err = ValidateAccessTokenStructure(payloadv3, version3)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary of change

Adds an additional test to make sure access token validation never fails because of claims that can be JSON null or skipped by the core

## Related issues

- 

## Test Plan

Adds new test

## Documentation changes

NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] ...
