### PR TITLE
fix: login methods api and tpless init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.13.1] - 2023-08-24
+
+-   Fixes login methods API to return empty provider array instead of `null`
+-   Fixes thirdpartypasswordless initialization when there are no static providers configured
+
 ## [0.13.0] - 2023-08-07
 
 ### Added

--- a/recipe/multitenancy/api/implementation.go
+++ b/recipe/multitenancy/api/implementation.go
@@ -27,7 +27,7 @@ func MakeAPIImplementation() multitenancymodels.APIInterface {
 
 		mergedProviders := tpproviders.MergeProvidersFromCoreAndStatic(providerConfigsFromCore, providerInputsFromStatic)
 
-		var finalProviderList []multitenancymodels.TypeThirdPartyProvider
+		var finalProviderList []multitenancymodels.TypeThirdPartyProvider = []multitenancymodels.TypeThirdPartyProvider{}
 
 		for _, providerInput := range mergedProviders {
 			providerInstance, err := tpproviders.FindAndCreateProviderInstance(mergedProviders, providerInput.Config.ThirdPartyId, clientType, userContext)

--- a/recipe/thirdpartyemailpassword/loginmethods_test.go
+++ b/recipe/thirdpartyemailpassword/loginmethods_test.go
@@ -1,0 +1,55 @@
+package thirdpartyemailpassword
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestLoginMethodsReturnEmptyProviderArray(t *testing.T) {
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	resp, err := http.Get(testServer.URL + "/auth/loginmethods")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	respObj := map[string]interface{}{}
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(respBytes, &respObj)
+	assert.Nil(t, err)
+	providersArr, ok := respObj["thirdParty"].(map[string]interface{})["providers"]
+	assert.True(t, ok)
+	assert.NotNil(t, providersArr)
+}

--- a/recipe/thirdpartypasswordless/config_test.go
+++ b/recipe/thirdpartypasswordless/config_test.go
@@ -83,6 +83,7 @@ func TestMinimumConfigForThirdPartyPasswordlessWithEmailOrPhoneContactMethod(t *
 	thirdPartyPasswordlessRecipe, err := GetRecipeInstanceOrThrowError()
 	assert.NoError(t, err)
 	assert.Equal(t, "USER_INPUT_CODE_AND_MAGIC_LINK", thirdPartyPasswordlessRecipe.Config.FlowType)
+	assert.NotNil(t, thirdPartyPasswordlessRecipe.thirdPartyRecipe) // thirdPartyRecipe must be created always
 }
 
 func TestForThirdPartyPasswordLessCreateAndSendCustomTextMessageWithFlowTypeMagicLinkAndPhoneContactMethod(t *testing.T) {

--- a/recipe/thirdpartypasswordless/recipe.go
+++ b/recipe/thirdpartypasswordless/recipe.go
@@ -107,29 +107,27 @@ func MakeRecipe(recipeId string, appInfo supertokens.NormalisedAppinfo, config t
 		r.passwordlessRecipe = passwordlessInstance
 	}
 
-	if len(verifiedConfig.Providers) > 0 {
-		if thirdPartyInstance == nil {
-			thirdPartyConfig := &tpmodels.TypeInput{
-				SignInAndUpFeature: tpmodels.TypeInputSignInAndUp{
-					Providers: verifiedConfig.Providers,
+	if thirdPartyInstance == nil {
+		thirdPartyConfig := &tpmodels.TypeInput{
+			SignInAndUpFeature: tpmodels.TypeInputSignInAndUp{
+				Providers: verifiedConfig.Providers,
+			},
+			Override: &tpmodels.OverrideStruct{
+				Functions: func(_ tpmodels.RecipeInterface) tpmodels.RecipeInterface {
+					return recipeimplementation.MakeThirdPartyRecipeImplementation(r.RecipeImpl)
 				},
-				Override: &tpmodels.OverrideStruct{
-					Functions: func(_ tpmodels.RecipeInterface) tpmodels.RecipeInterface {
-						return recipeimplementation.MakeThirdPartyRecipeImplementation(r.RecipeImpl)
-					},
-					APIs: func(_ tpmodels.APIInterface) tpmodels.APIInterface {
-						return api.GetThirdPartyIterfaceImpl(r.APIImpl)
-					},
+				APIs: func(_ tpmodels.APIInterface) tpmodels.APIInterface {
+					return api.GetThirdPartyIterfaceImpl(r.APIImpl)
 				},
-			}
-			thirdPartyRecipeinstance, err := thirdparty.MakeRecipe(recipeId, appInfo, thirdPartyConfig, &r.EmailDelivery, onSuperTokensAPIError)
-			if err != nil {
-				return Recipe{}, err
-			}
-			r.thirdPartyRecipe = &thirdPartyRecipeinstance
-		} else {
-			r.thirdPartyRecipe = thirdPartyInstance
+			},
 		}
+		thirdPartyRecipeinstance, err := thirdparty.MakeRecipe(recipeId, appInfo, thirdPartyConfig, &r.EmailDelivery, onSuperTokensAPIError)
+		if err != nil {
+			return Recipe{}, err
+		}
+		r.thirdPartyRecipe = &thirdPartyRecipeinstance
+	} else {
+		r.thirdPartyRecipe = thirdPartyInstance
 	}
 
 	return *r, nil

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.13.0"
+const VERSION = "0.13.1"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

- Login methods must return empty array and not null
- Thirdparty should be initialized when no static providers are configured

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
