### PR TITLE
refactor: Add handling for when Saas returns 429 because of rate limiting

### DIFF
--- a/recipe/session/querier_test.go
+++ b/recipe/session/querier_test.go
@@ -1,10 +1,9 @@
-package test
+package session
 
 import (
 	"encoding/json"
 	"errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/supertokens"
 	"net/http"
 	"net/http/httptest"
@@ -80,7 +79,7 @@ func TestThatNetworkCallIsRetried(t *testing.T) {
 			APIDomain:     "api.supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			session.Init(nil),
+			Init(nil),
 		},
 	}
 
@@ -155,7 +154,7 @@ func TestThatRateLimitErrorsAreThrownBackToTheUser(t *testing.T) {
 			APIDomain:     "api.supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			session.Init(nil),
+			Init(nil),
 		},
 	}
 
@@ -224,7 +223,7 @@ func TestThatParallelCallsHaveIndependentRetryCounters(t *testing.T) {
 			APIDomain:     "api.supertokens.io",
 		},
 		RecipeList: []supertokens.Recipe{
-			session.Init(nil),
+			Init(nil),
 		},
 	}
 

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -30,3 +30,5 @@ var (
 const DashboardVersion = "0.7"
 
 const DefaultTenantId string = "public"
+
+const RateLimitStatusCode = 429

--- a/supertokens/querier.go
+++ b/supertokens/querier.go
@@ -46,6 +46,10 @@ var (
 	querierHostLock       sync.Mutex
 )
 
+func SetQuerierApiVersionForTests(version string) {
+	querierAPIVersion = version
+}
+
 func (q *Querier) GetQuerierAPIVersion() (string, error) {
 	querierLock.Lock()
 	defer querierLock.Unlock()

--- a/test/querier_test.go
+++ b/test/querier_test.go
@@ -1,0 +1,283 @@
+package test
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func resetQuerier() {
+	supertokens.SetQuerierApiVersionForTests("")
+}
+
+func TestThatNetworkCallIsRetried(t *testing.T) {
+	mux := http.NewServeMux()
+
+	numberOfTimesCalled := 0
+	numberOfTimesSecondCalled := 0
+	numberOfTimesThirdCalled := 0
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesCalled++
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	mux.HandleFunc("/testing2", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesSecondCalled++
+		rw.Header().Set("Content-Type", "application/json")
+
+		if numberOfTimesSecondCalled == 3 {
+			rw.WriteHeader(200)
+		} else {
+			rw.WriteHeader(supertokens.RateLimitStatusCode)
+		}
+
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	mux.HandleFunc("/testing3", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesThirdCalled++
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(200)
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			session.Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing", map[string]string{})
+	if err == nil {
+		t.Error(errors.New("request should have failed but didnt").Error())
+	} else {
+		if !strings.Contains(err.Error(), "with status code: 429") {
+			t.Error(errors.New("request failed with an unexpected error").Error())
+		}
+	}
+
+	_, err = q.SendGetRequest("/testing2", map[string]string{})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing3", map[string]string{})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// One initial call + 5 retries
+	assert.Equal(t, numberOfTimesCalled, 6)
+	assert.Equal(t, numberOfTimesSecondCalled, 3)
+	assert.Equal(t, numberOfTimesThirdCalled, 1)
+}
+
+func TestThatRateLimitErrorsAreThrownBackToTheUser(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{
+			"status": "RATE_LIMIT_ERROR",
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			session.Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing", map[string]string{})
+	if err == nil {
+		t.Error(errors.New("request should have failed but didnt").Error())
+	} else {
+		if !strings.Contains(err.Error(), "with status code: 429") {
+			t.Error(errors.New("request failed with an unexpected error").Error())
+		}
+
+		assert.True(t, strings.Contains(err.Error(), "message: {\"status\":\"RATE_LIMIT_ERROR\"}"))
+	}
+}
+
+func TestThatParallelCallsHaveIndependentRetryCounters(t *testing.T) {
+	mux := http.NewServeMux()
+
+	numberOfTimesFirstCalled := 0
+	numberOfTimesSecondCalled := 0
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("id") == "1" {
+			numberOfTimesFirstCalled++
+		} else {
+			numberOfTimesSecondCalled++
+		}
+
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			session.Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		_, err = q.SendGetRequest("/testing", map[string]string{
+			"id": "1",
+		})
+		if err == nil {
+			t.Error(errors.New("request should have failed but didnt").Error())
+		} else {
+			if !strings.Contains(err.Error(), "with status code: 429") {
+				t.Error(errors.New("request failed with an unexpected error").Error())
+			}
+		}
+
+		wg.Done()
+	}()
+
+	go func() {
+		_, err = q.SendGetRequest("/testing", map[string]string{
+			"id": "2",
+		})
+		if err == nil {
+			t.Error(errors.New("request should have failed but didnt").Error())
+		} else {
+			if !strings.Contains(err.Error(), "with status code: 429") {
+				t.Error(errors.New("request failed with an unexpected error").Error())
+			}
+		}
+
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, numberOfTimesFirstCalled, 6)
+	assert.Equal(t, numberOfTimesSecondCalled, 6)
+}


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
