### PR TITLE
refactor: Add handling for when Saas returns 429 because of rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.11.1] - 2023-08-28
+
+- Adds logic to retry network calls if the core returns status 429
+
 ## [0.11.0] - 2023-04-28
 - Added missing arguments in `GetUsersNewestFirst` and `GetUsersOldestFirst`
 

--- a/recipe/session/querier_test.go
+++ b/recipe/session/querier_test.go
@@ -1,0 +1,285 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func resetQuerier() {
+	supertokens.SetQuerierApiVersionForTests("")
+}
+
+func TestThatNetworkCallIsRetried(t *testing.T) {
+	resetAll()
+	mux := http.NewServeMux()
+
+	numberOfTimesCalled := 0
+	numberOfTimesSecondCalled := 0
+	numberOfTimesThirdCalled := 0
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesCalled++
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	mux.HandleFunc("/testing2", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesSecondCalled++
+		rw.Header().Set("Content-Type", "application/json")
+
+		if numberOfTimesSecondCalled == 3 {
+			rw.WriteHeader(200)
+		} else {
+			rw.WriteHeader(supertokens.RateLimitStatusCode)
+		}
+
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	mux.HandleFunc("/testing3", func(rw http.ResponseWriter, r *http.Request) {
+		numberOfTimesThirdCalled++
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(200)
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing", map[string]string{})
+	if err == nil {
+		t.Error(errors.New("request should have failed but didnt").Error())
+	} else {
+		if !strings.Contains(err.Error(), "with status code: 429") {
+			t.Error(errors.New("request failed with an unexpected error").Error())
+		}
+	}
+
+	_, err = q.SendGetRequest("/testing2", map[string]string{})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing3", map[string]string{})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// One initial call + 5 retries
+	assert.Equal(t, numberOfTimesCalled, 6)
+	assert.Equal(t, numberOfTimesSecondCalled, 3)
+	assert.Equal(t, numberOfTimesThirdCalled, 1)
+}
+
+func TestThatRateLimitErrorsAreThrownBackToTheUser(t *testing.T) {
+	resetAll()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{
+			"status": "RATE_LIMIT_ERROR",
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = q.SendGetRequest("/testing", map[string]string{})
+	if err == nil {
+		t.Error(errors.New("request should have failed but didnt").Error())
+	} else {
+		if !strings.Contains(err.Error(), "with status code: 429") {
+			t.Error(errors.New("request failed with an unexpected error").Error())
+		}
+
+		assert.True(t, strings.Contains(err.Error(), "message: {\"status\":\"RATE_LIMIT_ERROR\"}"))
+	}
+}
+
+func TestThatParallelCallsHaveIndependentRetryCounters(t *testing.T) {
+	resetAll()
+	mux := http.NewServeMux()
+
+	numberOfTimesFirstCalled := 0
+	numberOfTimesSecondCalled := 0
+
+	mux.HandleFunc("/testing", func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("id") == "1" {
+			numberOfTimesFirstCalled++
+		} else {
+			numberOfTimesSecondCalled++
+		}
+
+		rw.WriteHeader(supertokens.RateLimitStatusCode)
+		rw.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]interface{}{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		rw.Write(response)
+	})
+
+	testServer := httptest.NewServer(mux)
+
+	defer func() {
+		testServer.Close()
+	}()
+
+	config := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			// We need the querier to call the test server and not the core
+			ConnectionURI: testServer.URL,
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(nil),
+		},
+	}
+
+	err := supertokens.Init(config)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	q, err := supertokens.GetNewQuerierInstanceOrThrowError("")
+	supertokens.SetQuerierApiVersionForTests("3.0")
+	defer resetQuerier()
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		_, err = q.SendGetRequest("/testing", map[string]string{
+			"id": "1",
+		})
+		if err == nil {
+			t.Error(errors.New("request should have failed but didnt").Error())
+		} else {
+			if !strings.Contains(err.Error(), "with status code: 429") {
+				t.Error(errors.New("request failed with an unexpected error").Error())
+			}
+		}
+
+		wg.Done()
+	}()
+
+	go func() {
+		_, err = q.SendGetRequest("/testing", map[string]string{
+			"id": "2",
+		})
+		if err == nil {
+			t.Error(errors.New("request should have failed but didnt").Error())
+		} else {
+			if !strings.Contains(err.Error(), "with status code: 429") {
+				t.Error(errors.New("request failed with an unexpected error").Error())
+			}
+		}
+
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, numberOfTimesFirstCalled, 6)
+	assert.Equal(t, numberOfTimesSecondCalled, 6)
+}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,10 +21,12 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.11.0"
+const VERSION = "0.11.1"
 
 var (
 	cdiSupported = []string{"2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18", "2.19", "2.20"}
 )
 
 const DashboardVersion = "0.6"
+
+const RateLimitStatusCode = 429

--- a/supertokens/querier.go
+++ b/supertokens/querier.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 type Querier struct {
@@ -45,6 +46,10 @@ var (
 	querierHostLock       sync.Mutex
 )
 
+func SetQuerierApiVersionForTests(version string) {
+	querierAPIVersion = version
+}
+
 func (q *Querier) GetQuerierAPIVersion() (string, error) {
 	querierLock.Lock()
 	defer querierLock.Unlock()
@@ -61,7 +66,7 @@ func (q *Querier) GetQuerierAPIVersion() (string, error) {
 		}
 		client := &http.Client{}
 		return client.Do(req)
-	}, len(QuerierHosts))
+	}, len(QuerierHosts), nil)
 
 	if err != nil {
 		return "", err
@@ -141,7 +146,7 @@ func (q *Querier) SendPostRequest(path string, data map[string]interface{}) (map
 
 		client := &http.Client{}
 		return client.Do(req)
-	}, len(QuerierHosts))
+	}, len(QuerierHosts), nil)
 }
 
 func (q *Querier) SendDeleteRequest(path string, data map[string]interface{}, params map[string]string) (map[string]interface{}, error) {
@@ -182,7 +187,7 @@ func (q *Querier) SendDeleteRequest(path string, data map[string]interface{}, pa
 
 		client := &http.Client{}
 		return client.Do(req)
-	}, len(QuerierHosts))
+	}, len(QuerierHosts), nil)
 }
 
 func (q *Querier) SendGetRequest(path string, params map[string]string) (map[string]interface{}, error) {
@@ -217,7 +222,7 @@ func (q *Querier) SendGetRequest(path string, params map[string]string) (map[str
 
 		client := &http.Client{}
 		return client.Do(req)
-	}, len(QuerierHosts))
+	}, len(QuerierHosts), nil)
 }
 
 func (q *Querier) SendPutRequest(path string, data map[string]interface{}) (map[string]interface{}, error) {
@@ -251,12 +256,12 @@ func (q *Querier) SendPutRequest(path string, data map[string]interface{}) (map[
 
 		client := &http.Client{}
 		return client.Do(req)
-	}, len(QuerierHosts))
+	}, len(QuerierHosts), nil)
 }
 
 type httpRequestFunction func(url string) (*http.Response, error)
 
-func (q *Querier) sendRequestHelper(path NormalisedURLPath, httpRequest httpRequestFunction, numberOfTries int) (map[string]interface{}, error) {
+func (q *Querier) sendRequestHelper(path NormalisedURLPath, httpRequest httpRequestFunction, numberOfTries int, retryInfoMap *map[string]int) (map[string]interface{}, error) {
 	if numberOfTries == 0 {
 		return nil, errors.New("no SuperTokens core available to query")
 	}
@@ -264,14 +269,32 @@ func (q *Querier) sendRequestHelper(path NormalisedURLPath, httpRequest httpRequ
 	querierHostLock.Lock()
 	currentDomain := QuerierHosts[querierLastTriedIndex].Domain.GetAsStringDangerous()
 	currentBasePath := QuerierHosts[querierLastTriedIndex].BasePath.GetAsStringDangerous()
+
+	url := currentDomain + currentBasePath + path.GetAsStringDangerous()
+
+	maxRetries := 5
+	var _retryInfoMap map[string]int
+
+	if retryInfoMap != nil {
+		_retryInfoMap = *retryInfoMap
+	} else {
+		_retryInfoMap = map[string]int{}
+	}
+
+	_, ok := _retryInfoMap[url]
+
+	if !ok {
+		_retryInfoMap[url] = maxRetries
+	}
+
 	querierLastTriedIndex = (querierLastTriedIndex + 1) % len(QuerierHosts)
 	querierHostLock.Unlock()
 
-	resp, err := httpRequest(currentDomain + currentBasePath + path.GetAsStringDangerous())
+	resp, err := httpRequest(url)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			return q.sendRequestHelper(path, httpRequest, numberOfTries-1)
+			return q.sendRequestHelper(path, httpRequest, numberOfTries-1, &_retryInfoMap)
 		}
 		if resp != nil {
 			resp.Body.Close()
@@ -286,6 +309,21 @@ func (q *Querier) sendRequestHelper(path NormalisedURLPath, httpRequest httpRequ
 		return nil, readErr
 	}
 	if resp.StatusCode != 200 {
+		if resp.StatusCode == RateLimitStatusCode {
+			retriesLeft := _retryInfoMap[url]
+
+			if retriesLeft > 0 {
+				_retryInfoMap[url] = retriesLeft - 1
+
+				attemptsMade := maxRetries - retriesLeft
+				delay := 10 + (250 * attemptsMade)
+
+				time.Sleep(time.Millisecond * time.Duration(delay))
+
+				return q.sendRequestHelper(path, httpRequest, numberOfTries, &_retryInfoMap)
+			}
+		}
+
 		return nil, fmt.Errorf("SuperTokens core threw an error for a request to path: '%s' with status code: %v and message: %s", path.GetAsStringDangerous(), resp.StatusCode, body)
 	}
 


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] ...
