### PR TITLE
Update adaptor middleware for GoFiber example

### DIFF
--- a/examples/with-fiber/main.go
+++ b/examples/with-fiber/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification/evmodels"


### PR DESCRIPTION
## Summary of change

Hello, I'm one of the GoFiber maintainers, I noticed the example for `gofiber` was still using the old `adaptor` repo. This PR fixes that by updating the import url.

The adaptor middleware was migrated to be part of `GoFiber` a few months ago. Docs here: https://docs.gofiber.io/api/middleware/adaptor
