### PR TITLE
refactor: Ignore protected props in create new session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   Dashboard APIs now return a status code `403` for all non-GET requests if the currently logged in Dashboard User is not listed in the `admins` array
+-   Now ignoring protected props in the payload in `CreateNewSession` and `CreateNewSessionWithoutRequestResponse`
 
 ## [0.13.2] - 2023-08-28
 

--- a/recipe/session/accessTokenVersions_test.go
+++ b/recipe/session/accessTokenVersions_test.go
@@ -171,34 +171,30 @@ func TestShouldThrowErrorWhenUsingProtectedProps(t *testing.T) {
 		testServer.Close()
 	}()
 
-	appSub := "asdf"
-	body := map[string]map[string]*string{
-		"payload": {
-			"sub": &appSub,
-		},
-	}
+	sessionResponse, err := CreateNewSessionWithoutRequestResponse("public", "testing", map[string]interface{}{
+		"customProps": "custom",
+	}, map[string]interface{}{}, nil)
 
-	postBody, err := json.Marshal(body)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	res2, err2 := http.Post(testServer.URL+"/create", "application/json", bytes.NewBuffer(postBody))
-	if err2 != nil {
-		t.Error(err2.Error())
-	}
-
-	assert.Equal(t, 200, res2.StatusCode)
-	cookies := unittesting.ExtractInfoFromResponse(res2)
-	assert.False(t, cookies["accessTokenFromAny"] == "")
-	assert.False(t, cookies["refreshTokenFromAny"] == "")
-	assert.False(t, cookies["frontToken"] == "")
-
-	parsedToken, err := ParseJWTWithoutSignatureVerification(cookies["accessTokenFromAny"])
 	if err != nil {
 		t.Error(err.Error())
 	}
 
-	assert.True(t, parsedToken.Payload["sub"] != "asdf")
+	newSession, err := CreateNewSessionWithoutRequestResponse("public", "testing2", sessionResponse.GetAccessTokenPayload(), map[string]interface{}{}, nil)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	accessToken := newSession.GetAccessToken()
+
+	parsedToken, err := ParseJWTWithoutSignatureVerification(accessToken)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	assert.True(t, parsedToken.Payload["customProps"] == "custom")
+	// This makes sure it does not reuse the sub from the old payload
+	assert.True(t, parsedToken.Payload["sub"] == "testing2")
 }
 
 func TestMergeIntoATShouldHelpMigratingV2TokenUsingProtectedProps(t *testing.T) {

--- a/recipe/session/accessTokenVersions_test.go
+++ b/recipe/session/accessTokenVersions_test.go
@@ -184,14 +184,21 @@ func TestShouldThrowErrorWhenUsingProtectedProps(t *testing.T) {
 	}
 	res2, err2 := http.Post(testServer.URL+"/create", "application/json", bytes.NewBuffer(postBody))
 	if err2 != nil {
+		t.Error(err2.Error())
+	}
+
+	assert.Equal(t, 200, res2.StatusCode)
+	cookies := unittesting.ExtractInfoFromResponse(res2)
+	assert.False(t, cookies["accessTokenFromAny"] == "")
+	assert.False(t, cookies["refreshTokenFromAny"] == "")
+	assert.False(t, cookies["frontToken"] == "")
+
+	parsedToken, err := ParseJWTWithoutSignatureVerification(cookies["accessTokenFromAny"])
+	if err != nil {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, 400, res2.StatusCode)
-	cookies := unittesting.ExtractInfoFromResponse(res2)
-	assert.True(t, cookies["accessTokenFromAny"] == "")
-	assert.True(t, cookies["refreshTokenFromAny"] == "")
-	assert.True(t, cookies["frontToken"] == "")
+	assert.True(t, parsedToken.Payload["sub"] != "asdf")
 }
 
 func TestMergeIntoATShouldHelpMigratingV2TokenUsingProtectedProps(t *testing.T) {

--- a/recipe/session/constants.go
+++ b/recipe/session/constants.go
@@ -31,3 +31,17 @@ const (
 	CookieSameSite_LAX    = "lax"
 	CookieSameSite_STRICT = "strict"
 )
+
+var JWKCacheMaxAgeInMs int64 = 60000
+var JWKRefreshRateLimit = 500
+var protectedProps = []string{
+	"sub",
+	"iat",
+	"exp",
+	"sessionHandle",
+	"parentRefreshTokenHash1",
+	"refreshTokenHash1",
+	"antiCsrfToken",
+	"rsub",
+	"tId",
+}

--- a/recipe/session/main.go
+++ b/recipe/session/main.go
@@ -64,6 +64,10 @@ func CreateNewSessionWithoutRequestResponse(tenantId string, userID string, acce
 
 	finalAccessTokenPayload["iss"] = issuer
 
+	for _, protectedProp := range protectedProps {
+		delete(finalAccessTokenPayload, protectedProp)
+	}
+
 	for _, claim := range claimsAddedByOtherRecipes {
 		finalAccessTokenPayload, err = claim.Build(userID, tenantId, finalAccessTokenPayload, userContext[0])
 		if err != nil {

--- a/recipe/session/recipeImplementation.go
+++ b/recipe/session/recipeImplementation.go
@@ -32,19 +32,6 @@ import (
 	"github.com/supertokens/supertokens-golang/supertokens"
 )
 
-var protectedProps = []string{
-	"sub",
-	"iat",
-	"exp",
-	"sessionHandle",
-	"parentRefreshTokenHash1",
-	"refreshTokenHash1",
-	"antiCsrfToken",
-	"tId",
-}
-
-var JWKCacheMaxAgeInMs int64 = 60000
-var JWKRefreshRateLimit = 500
 var jwksCache *sessmodels.GetJWKSResult = nil
 var mutex sync.RWMutex
 

--- a/recipe/session/sessionRequestFunctions.go
+++ b/recipe/session/sessionRequestFunctions.go
@@ -43,6 +43,10 @@ func CreateNewSessionInRequest(req *http.Request, res http.ResponseWriter, tenan
 	issuer := appInfo.APIDomain.GetAsStringDangerous() + appInfo.APIBasePath.GetAsStringDangerous()
 	finalAccessTokenPayload["iss"] = issuer
 
+	for _, protectedProp := range protectedProps {
+		delete(finalAccessTokenPayload, protectedProp)
+	}
+
 	for _, claim := range claimsAddedByOtherRecipes {
 		_finalAccessTokenPayload, err := claim.Build(userID, tenantId, finalAccessTokenPayload, userContext)
 		if err != nil {


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
