### PR TITLE
fix: Fix an issue where there would be duplicate headers in the value of Access-Control-Expose-Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.4] - 2023-10-20
+
+-   Fixes an issue where sometimes the `Access-Control-Expose-Headers` header value would contain duplicates
+
 ## [0.16.3] - 2023-10-19
 
 -   Fixes an issue where trying to view details of a third party user would show an error for the user not being found when using the thirdpartypasswordless recipe

--- a/recipe/session/cookieAndHeaders.go
+++ b/recipe/session/cookieAndHeaders.go
@@ -190,7 +190,15 @@ func setHeader(res http.ResponseWriter, key, value string, allowDuplicateKey boo
 	if existingValue == "" {
 		res.Header().Set(key, value)
 	} else if allowDuplicateKey {
-		res.Header().Set(key, existingValue+", "+value)
+		/**
+		We only want to append if it does not already exist
+
+		For example if the caller is trying to add front token to the access control exposed headers property
+		we do not want to append if something else had already added it
+		*/
+		if !strings.Contains(existingValue, value) {
+			res.Header().Set(key, existingValue+", "+value)
+		}
 	} else {
 		res.Header().Set(key, value)
 	}

--- a/recipe/session/verifySession_test.go
+++ b/recipe/session/verifySession_test.go
@@ -1112,14 +1112,20 @@ func TestThatResponseHeadersAreCorrectWhenUsingHeaders(t *testing.T) {
 
 	accessAllowHeaderValues := strings.Split(res.Header.Get("Access-Control-Expose-Headers"), ",")
 	frontTokenCount := 0
+	stAccessTokenCount := 0
 
 	for _, value := range accessAllowHeaderValues {
 		if strings.Contains(value, "front-token") {
 			frontTokenCount += 1
 		}
+
+		if strings.Contains(value, "st-access-token") {
+			stAccessTokenCount += 1
+		}
 	}
 
 	assert.Equal(t, frontTokenCount, 1)
+	assert.Equal(t, stAccessTokenCount, 1)
 }
 
 type typeTestEndpoint struct {

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.16.3"
+const VERSION = "0.16.4"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

Adds tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] ...
