### PR TITLE
feat: provide full config from file

### DIFF
--- a/examples/with-gin/config/config.go
+++ b/examples/with-gin/config/config.go
@@ -30,137 +30,27 @@ func Init() {
 		log.Fatal("error on parsing configuration file")
 	}
 
+	var providers []tpmodels.ProviderInput
+	err = config.UnmarshalKey("Providers", &providers)
+	if err != nil {
+		log.Fatal("invalid 'Providers' config, ", err)
+	}
+
 	err = supertokens.Init(supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{
-			ConnectionURI: "https://try.supertokens.io",
+			ConnectionURI: config.GetString("SuperTokens.ConnectionURI"),
 		},
 		AppInfo: supertokens.AppInfo{
-			AppName:       "SuperTokens Demo App",
-			APIDomain:     "http://localhost" + config.GetString("server.apiPort"),
-			WebsiteDomain: "http://localhost" + config.GetString("server.websitePort"),
+			AppName:       config.GetString("AppInfo.AppName"),
+			APIDomain:     config.GetString("AppInfo.APIDomain"),
+			WebsiteDomain: config.GetString("AppInfo.WebsiteDomain"),
 		},
 		RecipeList: []supertokens.Recipe{
 			emailverification.Init(evmodels.TypeInput{
 				Mode: evmodels.ModeRequired,
 			}),
 			thirdpartyemailpassword.Init(&tpepmodels.TypeInput{
-				/*
-				   We use different credentials for different platforms when required. For example the redirect URI for Github
-				   is different for Web and mobile. In such a case we can provide multiple providers with different client Ids.
-
-				   When the frontend makes a request and wants to use a specific clientId, it needs to send the clientId to use in the
-				   request. In the absence of a clientId in the request the SDK uses the default provider, indicated by `isDefault: true`.
-				   When adding multiple providers for the same type (Google, Github etc), make sure to set `isDefault: true`.
-				*/
-				Providers: []tpmodels.ProviderInput{
-					// We have provided you with development keys which you can use for testsing.
-					// IMPORTANT: Please replace them with your own OAuth keys for production use.
-					{
-						Config: tpmodels.ProviderConfig{
-							ThirdPartyId: "google",
-							Clients: []tpmodels.ProviderClientConfig{
-								{
-									ClientType:   "web",
-									ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
-									ClientSecret: "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",
-								},
-								{
-									// we use this for mobile apps
-									ClientType:   "mobile",
-									ClientID:     "1060725074195-c7mgk8p0h27c4428prfuo3lg7ould5o7.apps.googleusercontent.com",
-									ClientSecret: "", // this is empty because we follow Authorization code grant flow via PKCE for mobile apps (Google doesn't issue a client secret for mobile apps).
-								},
-							},
-						},
-					},
-					{
-						Config: tpmodels.ProviderConfig{
-							ThirdPartyId: "github",
-							Clients: []tpmodels.ProviderClientConfig{
-								{
-									ClientType:   "web",
-									ClientID:     "467101b197249757c71f",
-									ClientSecret: "e97051221f4b6426e8fe8d51486396703012f5bd",
-								},
-								{
-									// We use this for mobile apps
-									ClientType:   "mobile",
-									ClientID:     "8a9152860ce869b64c44",
-									ClientSecret: "00e841f10f288363cd3786b1b1f538f05cfdbda2",
-								},
-							},
-						},
-					},
-					/*
-					   For Apple signin, iOS apps always use the bundle identifier as the client ID when communicating with Apple. Android, Web and other platforms
-					   need to configure a Service ID on the Apple developer dashboard and use that as client ID.
-					   In the example below 4398792-io.supertokens.example.service is the client ID for Web. Android etc and thus we mark it as default. For iOS
-					   the frontend for the demo app sends the clientId in the request which is then used by the SDK.
-					*/
-					{
-						Config: tpmodels.ProviderConfig{
-							ThirdPartyId: "apple",
-							Clients: []tpmodels.ProviderClientConfig{
-								{
-									// For Android and website apps
-									ClientType: "web",
-									ClientID:   "4398792-io.supertokens.example.service",
-									AdditionalConfig: map[string]interface{}{
-										"keyId":      "7M48Y4RYDL",
-										"privateKey": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----",
-										"teamId":     "YWQCXGJRJL",
-									},
-								},
-								{
-									// For iOS Apps
-									ClientType: "ios",
-									ClientID:   "4398792-io.supertokens.example",
-									AdditionalConfig: map[string]interface{}{
-										"keyId":      "7M48Y4RYDL",
-										"privateKey": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----",
-										"teamId":     "YWQCXGJRJL",
-									},
-								},
-							},
-						},
-					},
-					{
-						Config: tpmodels.ProviderConfig{
-							ThirdPartyId: "discord",
-							Clients: []tpmodels.ProviderClientConfig{
-								{
-									ClientType:   "web",
-									ClientID:     "4398792-907871294886928395",
-									ClientSecret: "His4yXGEovVp5TZkZhEAt0ZXGh8uOVDm",
-								},
-								{
-									// We use this for mobile apps
-									ClientType:   "mobile",
-									ClientID:     "4398792-907871294886928395",
-									ClientSecret: "His4yXGEovVp5TZkZhEAt0ZXGh8uOVDm",
-								},
-							},
-						},
-					},
-					{
-						Config: tpmodels.ProviderConfig{
-							ThirdPartyId: "google-workspaces",
-							Clients: []tpmodels.ProviderClientConfig{
-								{
-									ClientType:   "web",
-									ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
-									ClientSecret: "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",
-								},
-								{
-									// We use this for mobile apps
-									ClientType:   "mobile",
-									ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
-									ClientSecret: "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",
-								},
-							},
-						},
-					},
-				},
+				Providers: providers,
 			}),
 			session.Init(nil),
 			dashboard.Init(nil),

--- a/examples/with-gin/config/dev.yaml
+++ b/examples/with-gin/config/dev.yaml
@@ -1,0 +1,93 @@
+AppInfo:
+  AppName: SuperTokens Demo App
+  APIDomain: http://localhost:3000
+  WebsiteDomain: http://localhost:8080
+
+Server:
+  Address: localhost:3000
+
+CORS:
+  AllowOrigins:
+  - http://localhost:3000
+  AllowMethods: ["GET", "POST", "DELETE", "PUT", "OPTIONS"]
+
+SuperTokens:
+  ConnectionURI: https://try.supertokens.io
+
+Providers:
+  #  We use different credentials for different platforms when required. For example the redirect URI for GitHub
+  #  is different for Web and mobile. In such a case we can provide multiple providers with different client Ids.
+  #
+  #  When the frontend makes a request and wants to use a specific clientId, it needs to send the clientId to use in the
+  #  request. In the absence of a clientId in the request the SDK uses the default provider, indicated by `isDefault: true`.
+  #  When adding multiple providers for the same type (Google, GitHub etc.), make sure to set `isDefault: true`.
+
+  #  We have provided you with development keys which you can use for testing.
+  #  IMPORTANT: Please replace them with your own OAuth keys for production use.
+
+  # Google:
+  - Config:
+      ThirdPartyId: google
+      Clients:
+        - ClientType: web
+          ClientID: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com"
+          ClientSecret: "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"
+        - ClientType: mobile # We use this for mobile apps
+          ClientID: "1060725074195-c7mgk8p0h27c4428prfuo3lg7ould5o7.apps.googleusercontent.com"
+          # ClientSecret is empty because we follow Authorization code grant flow via PKCE for
+          # mobile apps (Google doesn't issue a client secret for mobile apps):
+          ClientSecret: ""
+
+  # GitHub:
+  - Config:
+      ThirdPartyId: github
+      Clients:
+        - ClientType: web
+          ClientID: "467101b197249757c71f"
+          ClientSecret: "e97051221f4b6426e8fe8d51486396703012f5bd"
+        - ClientType: mobile # We use this for mobile apps
+          ClientID: "8a9152860ce869b64c44"
+          ClientSecret: "00e841f10f288363cd3786b1b1f538f05cfdbda2"
+
+  # Apple:
+  - Config:
+      ThirdPartyId: apple
+      # For Apple signin, iOS apps always use the bundle identifier as the client ID when communicating with Apple. Android, Web and other platforms
+      # need to configure a Service ID on the Apple developer dashboard and use that as client ID.
+      # In the example below 4398792-io.supertokens.example.service is the client ID for Web. Android etc and thus we mark it as default. For iOS
+      # the frontend for the demo app sends the clientId in the request which is then used by the SDK.
+      Clients:
+        - ClientType: web
+          ClientID: "4398792-io.supertokens.example.service"
+          AdditionalConfig:
+            keyId: "7M48Y4RYDL"
+            privateKey: "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----"
+            teamId: "YWQCXGJRJL"
+        - ClientType: ios
+          ClientID: "4398792-io.supertokens.example"
+          AdditionalConfig:
+            keyId: "7M48Y4RYDL"
+            privateKey: "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----"
+            teamId: "YWQCXGJRJL"
+
+  # Discord
+  - Config:
+      ThirdPartyId: discord
+      Clients:
+        - ClientType: web
+          ClientID: "4398792-907871294886928395"
+          ClientSecret: "His4yXGEovVp5TZkZhEAt0ZXGh8uOVDm"
+        - ClientType: mobile
+          ClientID: "4398792-907871294886928395"
+          ClientSecret: "His4yXGEovVp5TZkZhEAt0ZXGh8uOVDm"
+
+  # Google Workspaces:
+  - Config:
+      ThirdPartyId: google-workspaces
+      Clients:
+        - ClientType: web
+          ClientID: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com"
+          ClientSecret: "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"
+        - ClientType: mobile
+          ClientID: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com"
+          ClientSecret: "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"

--- a/examples/with-gin/server/server.go
+++ b/examples/with-gin/server/server.go
@@ -21,8 +21,8 @@ func Init() {
 
 	// CORS
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:3000"},
-		AllowMethods:     []string{"GET", "POST", "DELETE", "PUT", "OPTIONS"},
+		AllowOrigins:     config.GetStringSlice("CORS.AllowOrigins"),
+		AllowMethods:     config.GetStringSlice("CORS.AllowMethods"),
 		AllowHeaders:     append([]string{"content-type"}, supertokens.GetAllCORSHeaders()...),
 		MaxAge:           1 * time.Minute,
 		AllowCredentials: true,
@@ -41,7 +41,7 @@ func Init() {
 	router.GET("/sessioninfo", verifySession(nil), sessioninfo)
 
 	// starting the server
-	err := router.Run(config.GetString("server.apiPort"))
+	err := router.Run(config.GetString("Server.Address"))
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
## Summary of change

Adjust the Gin example, so that all config data is read from `dev.yaml`.
Therefore the config file is also included in this PR.
