### PR TITLE
fix: smtp tls config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.17.4] - 2024-02-08
+
+- Adds `TLSConfig` to SMTP settings.
+- `TLSConfig` is always passed to gomail so that it can be used when gomail uses `STARTTLS` to upgrade the connection to TLS.
+
 ## [0.17.3] - 2023-12-12
 
 - CI/CD changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds `TLSConfig` to SMTP settings.
 - `TLSConfig` is always passed to gomail so that it can be used when gomail uses `STARTTLS` to upgrade the connection to TLS. - https://github.com/supertokens/supertokens-golang/issues/392
+- Not setting `InsecureSkipVerify` to `true` in the SMTP settings because it is not recommended to use it in production.
 
 ## [0.17.3] - 2023-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.4] - 2024-02-08
 
 - Adds `TLSConfig` to SMTP settings.
-- `TLSConfig` is always passed to gomail so that it can be used when gomail uses `STARTTLS` to upgrade the connection to TLS.
+- `TLSConfig` is always passed to gomail so that it can be used when gomail uses `STARTTLS` to upgrade the connection to TLS. - https://github.com/supertokens/supertokens-golang/issues/392
 
 ## [0.17.3] - 2023-12-12
 

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -59,8 +59,13 @@ func SendSMTPEmail(settings SMTPSettings, content EmailContent) error {
 
 	d := gomail.NewDialer(settings.Host, settings.Port, username, settings.Password)
 
-	if settings.Secure {
+	if settings.TLSConfig != nil {
+		d.TLSConfig = settings.TLSConfig
+	} else {
 		d.TLSConfig = &tls.Config{InsecureSkipVerify: true, ServerName: settings.Host}
+	}
+
+	if settings.Secure {
 		d.SSL = true
 	}
 	return d.DialAndSend(m)

--- a/ingredients/emaildelivery/main.go
+++ b/ingredients/emaildelivery/main.go
@@ -58,11 +58,10 @@ func SendSMTPEmail(settings SMTPSettings, content EmailContent) error {
 	}
 
 	d := gomail.NewDialer(settings.Host, settings.Port, username, settings.Password)
-
 	if settings.TLSConfig != nil {
 		d.TLSConfig = settings.TLSConfig
 	} else {
-		d.TLSConfig = &tls.Config{InsecureSkipVerify: true, ServerName: settings.Host}
+		d.TLSConfig = &tls.Config{ServerName: settings.Host}
 	}
 
 	if settings.Secure {

--- a/ingredients/emaildelivery/smtpmodels.go
+++ b/ingredients/emaildelivery/smtpmodels.go
@@ -17,16 +17,19 @@
 package emaildelivery
 
 import (
+	"crypto/tls"
+
 	"github.com/supertokens/supertokens-golang/supertokens"
 )
 
 type SMTPSettings struct {
-	Host     string
-	From     SMTPFrom
-	Port     int
-	Username *string
-	Password string
-	Secure   bool
+	Host      string
+	From      SMTPFrom
+	Port      int
+	Username  *string
+	Password  string
+	Secure    bool
+	TLSConfig *tls.Config
 }
 
 type SMTPFrom struct {

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.17.3"
+const VERSION = "0.17.4"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

Adds `TLSConfig` to `SMTPSettings` using which user can specify custom TLS config
Passes TLSConfig always to gomail so that it can be used when automatically using START TLS

## Related issues

-   https://github.com/supertokens/supertokens-golang/issues/392

## Test Plan

Manually tested

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
