### PR TITLE
Added typing to avoid overflow warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.17.5] - 2024-03-14
+- Adds a type uint64 to the `accessTokenCookiesExpiryDurationMillis` local variable in `recipe/session/utils.go`. It also removes the redundant `uint64` type forcing needed because of the untyped variable.
+
 ## [0.17.4] - 2024-02-08
 
 - Adds `TLSConfig` to SMTP settings.

--- a/recipe/session/utils.go
+++ b/recipe/session/utils.go
@@ -239,7 +239,7 @@ func ValidateAndNormaliseUserInput(appInfo supertokens.NormalisedAppinfo, config
 	return typeNormalisedInput, nil
 }
 
-var accessTokenCookiesExpiryDurationMillis = 3153600000000
+var accessTokenCookiesExpiryDurationMillis uint64 = 3153600000000
 
 func normaliseSameSiteOrThrowError(sameSite string) (string, error) {
 	sameSite = strings.TrimSpace(sameSite)

--- a/recipe/session/utils.go
+++ b/recipe/session/utils.go
@@ -301,14 +301,14 @@ func SetAccessTokenInResponse(config sessmodels.TypeNormalisedInput, res http.Re
 	// This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
 	// Even if the token is expired the presence of the token indicates that the user could have a valid refresh
 	// Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-	setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+uint64(accessTokenCookiesExpiryDurationMillis), tokenTransferMethod, request, userContext)
+	setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+accessTokenCookiesExpiryDurationMillis, tokenTransferMethod, request, userContext)
 
 	if config.ExposeAccessTokenToFrontendInCookieBasedAuth && tokenTransferMethod == sessmodels.CookieTransferMethod {
 		// We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
 		// This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
 		// Even if the token is expired the presence of the token indicates that the user could have a valid refresh
 		// Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-		setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+uint64(accessTokenCookiesExpiryDurationMillis), sessmodels.HeaderTransferMethod, request, userContext)
+		setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+accessTokenCookiesExpiryDurationMillis, sessmodels.HeaderTransferMethod, request, userContext)
 	}
 	return nil
 }

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.17.4"
+const VERSION = "0.17.5"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

SuperTokens-golang **Version 0.17.4**

This PR Adds a type `uint64` to the `accessTokenCookiesExpiryDurationMillis` local variable in `recipe/session/utils.go`. It also removes the redundant `uint64` type forcing needed because of the untyped variable.

### Reason:

While using GoReleaser to generate a release of my project using the supertokens-golang SDK it flagged an error building the binary for `linux_386` | `Linux i386`.

### The error:

```bash
⨯ release failed after 52s  error=failed to build for linux_386: exit status 1: # github.com/supertokens/supertokens-golang/recipe/session
/root/go/pkg/mod/github.com/supertokens/supertokens-golang@v0.17.4/recipe/session/utils.go:242:46: cannot use 3153600000000 (untyped int constant) as int value in variable declaration (overflows)
```

## Related issues

#398 GoReleaser Fails on account of an untyped variable declaration

## Test Plan

There were no dedicated test cases in the `utils_test.go` file. However the locally affected variable can be tested to make sure of type and overflow but running it against it's local case: `GetCurrTimeInMS() + accessTokenCookiesExpiryDurationMillis`. I will provide a screenshot of the output in the GoBetterPlayground and a link below.

[Go Better Playground Test](https://goplay.tools/snippet/KRm_BE6VaFJ)

<img width="608" alt="ad301f71f1a905288ca6ac96f1395ffb" src="https://github.com/supertokens/supertokens-golang/assets/22087888/67677be5-5b8b-41ee-8b40-f687fa655710">

## Documentation changes

Not-relevant for documentation changes.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Create actual tests in the `utils_test.go` folder if required.
