### PR TITLE
fix: smooth switching between useDynamicAccessTokenSigningKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.17.6] - 2024-04-04
+
+- Enable smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to change the signing key type of a session
 
 ## [0.17.5] - 2024-03-14
+
 - Adds a type uint64 to the `accessTokenCookiesExpiryDurationMillis` local variable in `recipe/session/utils.go`. It also removes the redundant `uint64` type forcing needed because of the untyped variable.
 - Fixes the passing of `tenantId` in `getAllSessionHandlesForUser` and `revokeAllSessionsForUser` based on `fetchAcrossAllTenants` and `revokeAcrossAllTenants` inputs respectively.
 - Updated fake email generation

--- a/recipe/session/recipeImplementation.go
+++ b/recipe/session/recipeImplementation.go
@@ -294,7 +294,7 @@ func MakeRecipeImplementation(querier supertokens.Querier, config sessmodels.Typ
 
 		supertokens.LogDebugMessage("refreshSession: Started")
 
-		response, err := refreshSessionHelper(config, querier, refreshToken, antiCsrfToken, disableAntiCsrf, userContext)
+		response, err := refreshSessionHelper(config, querier, refreshToken, antiCsrfToken, disableAntiCsrf, config.UseDynamicAccessTokenSigningKey, userContext)
 		if err != nil {
 			return nil, err
 		}

--- a/recipe/session/sessionFunctions.go
+++ b/recipe/session/sessionFunctions.go
@@ -224,10 +224,11 @@ func getSessionInformationHelper(querier supertokens.Querier, sessionHandle stri
 	return nil, nil
 }
 
-func refreshSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens.Querier, refreshToken string, antiCsrfToken *string, disableAntiCsrf bool, userContext supertokens.UserContext) (sessmodels.CreateOrRefreshAPIResponse, error) {
+func refreshSessionHelper(config sessmodels.TypeNormalisedInput, querier supertokens.Querier, refreshToken string, antiCsrfToken *string, disableAntiCsrf bool, useDynamicAccessTokenSigningKey bool, userContext supertokens.UserContext) (sessmodels.CreateOrRefreshAPIResponse, error) {
 	requestBody := map[string]interface{}{
-		"refreshToken":   refreshToken,
-		"enableAntiCsrf": !disableAntiCsrf && config.AntiCsrfFunctionOrString.StrValue == AntiCSRF_VIA_TOKEN,
+		"refreshToken":         refreshToken,
+		"enableAntiCsrf":       !disableAntiCsrf && config.AntiCsrfFunctionOrString.StrValue == AntiCSRF_VIA_TOKEN,
+		"useDynamicSigningKey": useDynamicAccessTokenSigningKey,
 	}
 	if antiCsrfToken != nil {
 		requestBody["antiCsrfToken"] = *antiCsrfToken

--- a/recipe/session/switchingUseDynamicAccessTokenSigningKey_test.go
+++ b/recipe/session/switchingUseDynamicAccessTokenSigningKey_test.go
@@ -1,0 +1,162 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestUseDynamicAccessTokenSigningKeySwitchingFromTrueToFalse(t *testing.T) {
+	True := true
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&sessmodels.TypeInput{
+				UseDynamicAccessTokenSigningKey: &True,
+			}),
+		},
+	}
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	res, err := CreateNewSessionWithoutRequestResponse("public", "test-user-id", map[string]interface{}{
+		"tokenProp": true,
+	}, map[string]interface{}{
+		"dbProp": true,
+	}, nil)
+	assert.Nil(t, err)
+
+	tokens := res.GetAllSessionTokensDangerously()
+	checkAccessTokenSigningKeyType(t, tokens, true)
+
+	resetAll()
+	False := false
+	configValue = supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&sessmodels.TypeInput{
+				UseDynamicAccessTokenSigningKey: &False,
+			}),
+		},
+	}
+
+	err = supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = GetSessionWithoutRequestResponse(tokens.AccessToken, tokens.AntiCsrfToken, nil)
+	assert.NotNil(t, err)
+
+	assert.Equal(t, "The access token doesn't match the useDynamicAccessTokenSigningKey setting", err.Error())
+}
+
+func TestUseDynamicAccessTokenSigningKeySwitchingFromTrueToFalseShouldWorkAfterRefresh(t *testing.T) {
+	True := true
+	configValue := supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&sessmodels.TypeInput{
+				UseDynamicAccessTokenSigningKey: &True,
+			}),
+		},
+	}
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	res, err := CreateNewSessionWithoutRequestResponse("public", "test-user-id", map[string]interface{}{
+		"tokenProp": true,
+	}, map[string]interface{}{
+		"dbProp": true,
+	}, nil)
+	assert.Nil(t, err)
+
+	tokens := res.GetAllSessionTokensDangerously()
+	checkAccessTokenSigningKeyType(t, tokens, true)
+
+	resetAll()
+	False := false
+	configValue = supertokens.TypeInput{
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: "http://localhost:8080",
+		},
+		AppInfo: supertokens.AppInfo{
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+			APIDomain:     "api.supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			Init(&sessmodels.TypeInput{
+				UseDynamicAccessTokenSigningKey: &False,
+			}),
+		},
+	}
+
+	err = supertokens.Init(configValue)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	refreshedSession, err := RefreshSessionWithoutRequestResponse(*tokens.RefreshToken, nil, tokens.AntiCsrfToken)
+	assert.Nil(t, err)
+
+	tokens = refreshedSession.GetAllSessionTokensDangerously()
+	checkAccessTokenSigningKeyType(t, tokens, false)
+
+	verifiedSession, err := GetSessionWithoutRequestResponse(tokens.AccessToken, tokens.AntiCsrfToken, nil)
+	assert.Nil(t, err)
+
+	tokensAfterVerify := verifiedSession.GetAllSessionTokensDangerously()
+	assert.True(t, tokensAfterVerify.AccessAndFrontendTokenUpdated)
+
+	verified2Session, err := GetSessionWithoutRequestResponse(tokensAfterVerify.AccessToken, tokensAfterVerify.AntiCsrfToken, nil)
+	assert.Nil(t, err)
+
+	tokensAfterVerify2 := verified2Session.GetAllSessionTokensDangerously()
+	assert.False(t, tokensAfterVerify2.AccessAndFrontendTokenUpdated)
+}
+
+func checkAccessTokenSigningKeyType(t *testing.T, tokens sessmodels.SessionTokens, isDynamic bool) {
+	info, err := ParseJWTWithoutSignatureVerification(tokens.AccessToken)
+	assert.Nil(t, err)
+	if isDynamic {
+		assert.True(t, strings.HasPrefix(*info.KID, "d-"))
+	} else {
+		assert.True(t, strings.HasPrefix(*info.KID, "s-"))
+	}
+}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.17.5"
+const VERSION = "0.17.6"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
