### PR TITLE
fix: default to st-auth-mode if getTokenTransferMethod returns any in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- `session.CreateNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `config.GetTokenTransferMethod` returns `any`.
 
 ## [0.17.5] - 2024-03-14
 - Adds a type uint64 to the `accessTokenCookiesExpiryDurationMillis` local variable in `recipe/session/utils.go`. It also removes the redundant `uint64` type forcing needed because of the untyped variable.

--- a/recipe/emailpassword/authMode_test.go
+++ b/recipe/emailpassword/authMode_test.go
@@ -224,15 +224,43 @@ func TestWithGetTokenTransferMethodProvidedCreateNewSessionWithShouldUseHeaderIf
 	defer testServer.Close()
 	setupRoutesForTest(t, mux)
 
-	resp := createNewSession(t, testServer.URL, nil, nil, nil, nil)
+	t.Run("no st-auth-mode", func(t *testing.T) {
+		resp := createNewSession(t, testServer.URL, nil, nil, nil, nil)
 
-	assert.Equal(t, resp["sAccessToken"], "-not-present-")
-	assert.Equal(t, resp["sRefreshToken"], "-not-present-")
-	assert.Equal(t, resp["antiCsrf"], "-not-present-")
-	assert.NotEmpty(t, resp["accessTokenFromHeader"])
-	assert.NotEqual(t, resp["accessTokenFromHeader"], "-not-present-")
-	assert.NotEmpty(t, resp["refreshTokenFromHeader"])
-	assert.NotEqual(t, resp["refreshTokenFromHeader"], "-not-present-")
+		assert.Equal(t, resp["sAccessToken"], "-not-present-")
+		assert.Equal(t, resp["sRefreshToken"], "-not-present-")
+		assert.Equal(t, resp["antiCsrf"], "-not-present-")
+		assert.NotEmpty(t, resp["accessTokenFromHeader"])
+		assert.NotEqual(t, resp["accessTokenFromHeader"], "-not-present-")
+		assert.NotEmpty(t, resp["refreshTokenFromHeader"])
+		assert.NotEqual(t, resp["refreshTokenFromHeader"], "-not-present-")
+	})
+
+	t.Run("st-auth-mode is cookie", func(t *testing.T) {
+		authMode := string(sessmodels.CookieTransferMethod)
+		resp := createNewSession(t, testServer.URL, &authMode, nil, nil, nil)
+
+		assert.NotEqual(t, resp["sAccessToken"], "-not-present-")
+		assert.NotEqual(t, resp["sRefreshToken"], "-not-present-")
+		assert.NotEqual(t, resp["antiCsrf"], "-not-present-")
+		assert.NotEmpty(t, resp["accessTokenFromHeader"])
+		assert.Equal(t, resp["accessTokenFromHeader"], "-not-present-")
+		assert.NotEmpty(t, resp["refreshTokenFromHeader"])
+		assert.Equal(t, resp["refreshTokenFromHeader"], "-not-present-")
+	})
+
+	t.Run("st-auth-mode is header", func(t *testing.T) {
+		authMode := string(sessmodels.HeaderTransferMethod)
+		resp := createNewSession(t, testServer.URL, &authMode, nil, nil, nil)
+
+		assert.Equal(t, resp["sAccessToken"], "-not-present-")
+		assert.Equal(t, resp["sRefreshToken"], "-not-present-")
+		assert.Equal(t, resp["antiCsrf"], "-not-present-")
+		assert.NotEmpty(t, resp["accessTokenFromHeader"])
+		assert.NotEqual(t, resp["accessTokenFromHeader"], "-not-present-")
+		assert.NotEmpty(t, resp["refreshTokenFromHeader"])
+		assert.NotEqual(t, resp["refreshTokenFromHeader"], "-not-present-")
+	})
 }
 
 func TestWithGetTokenTransferMethodProvidedCreateNewSessionWithShouldUseHeaderIfMethodReturnsHeader(t *testing.T) {

--- a/recipe/session/sessionRequestFunctions.go
+++ b/recipe/session/sessionRequestFunctions.go
@@ -60,7 +60,12 @@ func CreateNewSessionInRequest(req *http.Request, res http.ResponseWriter, tenan
 
 	outputTokenTransferMethod := config.GetTokenTransferMethod(req, true, userContext)
 	if outputTokenTransferMethod == sessmodels.AnyTransferMethod {
-		outputTokenTransferMethod = sessmodels.HeaderTransferMethod
+		authMode := GetAuthmodeFromHeader(req)
+		if authMode != nil && *authMode == sessmodels.CookieTransferMethod {
+			outputTokenTransferMethod = *authMode
+		} else {
+			outputTokenTransferMethod = sessmodels.HeaderTransferMethod
+		}
 	}
 
 	supertokens.LogDebugMessage(fmt.Sprintf("createNewSession: using transfer method %s", outputTokenTransferMethod))


### PR DESCRIPTION
… createNewSession

## Summary of change

`CreateNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `GetTokenTransferMethod` returns `any`.

## Related issues

-  https://discordapp.com/channels/603466164219281420/1195351655093370880

## Test Plan

Added tests that check the output of createNewSession if:

- `GetTokenTransferMethod` returns any
- `st-auth-mode` is: `cookie`, `header`, or not set

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

