### PR TITLE
fix: session required in signout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `session.CreateNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `config.GetTokenTransferMethod` returns `any`.
 - Enable smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to change the signing key type of a session.
+- Make session required during signout.
 
 ## [0.17.5] - 2024-03-14
 - Adds a type uint64 to the `accessTokenCookiesExpiryDurationMillis` local variable in `recipe/session/utils.go`. It also removes the redundant `uint64` type forcing needed because of the untyped variable.

--- a/recipe/emailpassword/authFlow_test.go
+++ b/recipe/emailpassword/authFlow_test.go
@@ -1387,7 +1387,7 @@ func TestDefaultSignoutRouteRevokesSession(t *testing.T) {
 	assert.Equal(t, "", cookieData1["refreshTokenDomain"])
 }
 
-func TestCallingTheAPIwithoutSessionShouldReturnOk(t *testing.T) {
+func TestCallingTheAPIwithoutSessionShouldReturnUnauthorized(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{
 			ConnectionURI: "http://localhost:8080",
@@ -1442,8 +1442,8 @@ func TestCallingTheAPIwithoutSessionShouldReturnOk(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "OK", data["status"])
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.Empty(t, data["status"])
 	assert.Nil(t, req.Header["Cookie"])
 }
 

--- a/recipe/session/signout.go
+++ b/recipe/session/signout.go
@@ -27,9 +27,9 @@ func SignOutAPI(apiImplementation sessmodels.APIInterface, options sessmodels.AP
 		return nil
 	}
 
-	False := false
+	sessionRequired := true
 	sessionContainer, err := GetSessionFromRequest(options.Req, options.Res, options.Config, &sessmodels.VerifySessionOptions{
-		SessionRequired: &False,
+		SessionRequired: &sessionRequired,
 		OverrideGlobalClaimValidators: func(globalClaimValidators []claims.SessionClaimValidator, sessionContainer sessmodels.SessionContainer, userContext supertokens.UserContext) ([]claims.SessionClaimValidator, error) {
 			return []claims.SessionClaimValidator{}, nil
 		},

--- a/recipe/thirdparty/signoutFeature_test.go
+++ b/recipe/thirdparty/signoutFeature_test.go
@@ -35,7 +35,7 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestThatCallingTheAPIwithoutASessionShouldReturnOk(t *testing.T) {
+func TestThatCallingTheAPIwithoutASessionShouldReturnUnauthorized(t *testing.T) {
 	configValue := supertokens.TypeInput{
 		Supertokens: &supertokens.ConnectionInfo{
 			ConnectionURI: "http://localhost:8080",
@@ -80,7 +80,7 @@ func TestThatCallingTheAPIwithoutASessionShouldReturnOk(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 	dataInBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -94,7 +94,7 @@ func TestThatCallingTheAPIwithoutASessionShouldReturnOk(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	assert.Equal(t, "OK", response["status"])
+	assert.Empty(t, response["status"])
 
 	assert.Equal(t, 0, len(resp.Cookies()))
 }


### PR DESCRIPTION
## Summary of change

Fixing session required during signout

## Related issues

https://github.com/supertokens/supertokens-core/issues/554



## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
