### PR TITLE
fix: normaliseSessionScope and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.18.1] - 2024-05-01
+
+- Fixed a bug in the `normaliseSessionScopeOrThrowError` util function that caused it to remove leading dots from the scope string.
+
 ## [0.18.0] - 2024-04-30
 
 ### Changes

--- a/recipe/session/session_utils_test.go
+++ b/recipe/session/session_utils_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormaliseSessionScope(t *testing.T) {
+	t.Run("test with leading dot", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError(".example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, ".example.com", *result)
+	})
+
+	t.Run("test without leading dot", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "example.com", *result)
+	})
+
+	t.Run("test with http prefix", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("http://example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "example.com", *result)
+	})
+
+	t.Run("test with https prefix", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("https://example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "example.com", *result)
+	})
+
+	t.Run("test with IP address", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("192.168.1.1")
+		assert.NoError(t, err)
+		assert.Equal(t, "192.168.1.1", *result)
+	})
+
+	t.Run("test with localhost", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("localhost")
+		assert.NoError(t, err)
+		assert.Equal(t, "localhost", *result)
+	})
+
+	t.Run("test with leading and trailing whitespace", func(t *testing.T) {
+		result, err := normaliseSessionScopeOrThrowError("  example.com  ")
+		assert.NoError(t, err)
+		assert.Equal(t, "example.com", *result)
+	})
+}

--- a/recipe/session/utils.go
+++ b/recipe/session/utils.go
@@ -259,35 +259,45 @@ func GetURLScheme(URL string) (string, error) {
 }
 
 func normaliseSessionScopeOrThrowError(sessionScope string) (*string, error) {
-	sessionScope = strings.TrimSpace(sessionScope)
-	sessionScope = strings.ToLower(sessionScope)
+	helper := func(scope string) (string, error) {
+		scope = strings.TrimSpace(scope)
+		scope = strings.ToLower(scope)
 
-	sessionScope = strings.TrimPrefix(sessionScope, ".")
+		scope = strings.TrimPrefix(scope, ".")
 
-	if !strings.HasPrefix(sessionScope, "http://") && !strings.HasPrefix(sessionScope, "https://") {
-		sessionScope = "http://" + sessionScope
+		if !strings.HasPrefix(scope, "http://") && !strings.HasPrefix(scope, "https://") {
+			scope = "http://" + scope
+		}
+
+		parsedURL, err := url.Parse(scope)
+		if err != nil {
+			return "", errors.New("please provide a valid sessionScope")
+		}
+
+		hostname := parsedURL.Hostname()
+
+		return hostname, nil
 	}
 
-	urlObj, err := url.Parse(sessionScope)
+	noDotNormalised, err := helper(sessionScope)
 	if err != nil {
-		return nil, errors.New("Please provide a valid sessionScope")
+		return nil, err
 	}
-
-	sessionScope = urlObj.Hostname()
-	sessionScope = strings.TrimPrefix(sessionScope, ".")
-
-	noDotNormalised := sessionScope
 
 	isAnIP, err := supertokens.IsAnIPAddress(sessionScope)
 	if err != nil {
 		return nil, err
 	}
-	if sessionScope == "localhost" || isAnIP {
-		noDotNormalised = sessionScope
+
+	if noDotNormalised == "localhost" || isAnIP {
+		return &noDotNormalised, nil
 	}
+
 	if strings.HasPrefix(sessionScope, ".") {
-		noDotNormalised = "." + sessionScope
+		noDotNormalised = "." + noDotNormalised
+		return &noDotNormalised, nil
 	}
+
 	return &noDotNormalised, nil
 }
 

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.18.0"
+const VERSION = "0.18.1"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

Fixes the `normaliseSessionScopeOrThrowError` function and adds tests for it.

## Related issues

-  https://github.com/supertokens/supertokens-python/pull/496
-  https://github.com/supertokens/supertokens-node/pull/825

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 
