### PR TITLE
fix: the with-labstack-echo example

### DIFF
--- a/examples/with-labstack-echo/main.go
+++ b/examples/with-labstack-echo/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 	"net/http"
 	"strings"
+
+	"github.com/supertokens/supertokens-golang/recipe/dashboard"
 
 	"github.com/labstack/echo/v4"
 	"github.com/supertokens/supertokens-golang/recipe/emailverification"
@@ -200,8 +201,14 @@ func verifySession(options *sessmodels.VerifySessionOptions) echo.MiddlewareFunc
 		return func(c echo.Context) error {
 			session.VerifySession(options, func(rw http.ResponseWriter, r *http.Request) {
 				c.Set("session", session.GetSessionFromRequestContext(r.Context()))
-				hf(c)
+
+				// Call the handler
+				err := hf(c)
+				if err != nil {
+					c.Error(err)
+				}
 			})(c.Response(), c.Request())
+
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary of change

The issue is related to the usage of echo middleware in the `with-labstack-echo` example. Returning the `hf(c)` call will fix it.

**Why does it fix the issue?**
Because the error returned from the handler function is ignored when you don't return its result in the middleware chain. In the example, it ignores what `hf(c)` returns, instead returns `nil`. When we return as `return hf(c)`, the result of `hf(c)` will be respected.

## Related issues

https://discord.com/channels/603466164219281420/1227846962477535232

## Test Plan

Added a test.

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

