### PR TITLE
fix: update access token cookie expiry to 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.22.0] - 2024-06-24
+
+### Breaking change
+
+-   The access token cookie expiry has been changed from 100 years to 1 year due to some browsers capping the maximum expiry at 400 days. No action is needed on your part.
+
 ## [0.21.0] - 2024-06-10
 - Adds caching per API based on user context.
 

--- a/recipe/session/utils.go
+++ b/recipe/session/utils.go
@@ -257,7 +257,7 @@ func ValidateAndNormaliseUserInput(appInfo supertokens.NormalisedAppinfo, config
 	return typeNormalisedInput, nil
 }
 
-var accessTokenCookiesExpiryDurationMillis uint64 = 3153600000000
+var accessTokenCookiesExpiryDurationMillis uint64 = 31536000000
 
 func normaliseSameSiteOrThrowError(sameSite string) (string, error) {
 	sameSite = strings.TrimSpace(sameSite)
@@ -325,17 +325,17 @@ func GetCurrTimeInMS() uint64 {
 
 func SetAccessTokenInResponse(config sessmodels.TypeNormalisedInput, res http.ResponseWriter, accessToken string, frontToken string, tokenTransferMethod sessmodels.TokenTransferMethod, request *http.Request, userContext supertokens.UserContext) error {
 	setFrontTokenInHeaders(res, frontToken)
-	// We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+	// We set the expiration to 1 year, because we can't really access the expiration of the refresh token everywhere we are setting it.
 	// This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
 	// Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-	// Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
+	// Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
 	setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+accessTokenCookiesExpiryDurationMillis, tokenTransferMethod, request, userContext)
 
 	if config.ExposeAccessTokenToFrontendInCookieBasedAuth && tokenTransferMethod == sessmodels.CookieTransferMethod {
-		// We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+		// We set the expiration to 1 year, because we can't really access the expiration of the refresh token everywhere we are setting it.
 		// This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
 		// Even if the token is expired the presence of the token indicates that the user could have a valid refresh
-		// Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
+		// Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
 		setToken(config, res, sessmodels.AccessToken, accessToken, GetCurrTimeInMS()+accessTokenCookiesExpiryDurationMillis, sessmodels.HeaderTransferMethod, request, userContext)
 	}
 	return nil

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.21.0"
+const VERSION = "0.22.0"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

We decided to update the cookie expiry to 1 year because - 

1. Some browsers cap the max expiry to 400 days. See [this](https://developer.chrome.com/blog/cookie-max-age-expires#:~:text=With%20this%20change%2C%20Chrome%20caps,set%20to%20400%20days%20instead) for info.
2. Our docs mention that access token cookie expiry is 1 year.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

