### PR TITLE
test: move the session object and claims to the BE sdk server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.22.1] - 2024-07-09
+
+### Changes
+
+-   `refreshPOST` and `RefreshSession` now clears all user tokens upon CSRF failures and if no tokens are found. See the latest comment on https://github.com/supertokens/supertokens-node/issues/141 for more details.
+
 ## [0.22.0] - 2024-06-24
 
 ### Breaking change

--- a/recipe/emailpassword/authMode_test.go
+++ b/recipe/emailpassword/authMode_test.go
@@ -1145,14 +1145,14 @@ func TestRefreshTokenBehaviour(t *testing.T) {
 		setTokens                 string
 		clearedTokens             string
 	}{
-		{getTokenTransferMethodRes: "any", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none"},
-		{getTokenTransferMethodRes: "header", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none"},
-		{getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none"},
+		{getTokenTransferMethodRes: "any", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both"},
+		{getTokenTransferMethodRes: "header", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both"},
+		{getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both"},
 		{getTokenTransferMethodRes: "any", authHeader: false, authCookie: true, output: "validatecookie", setTokens: "cookies", clearedTokens: "none"},
-		{getTokenTransferMethodRes: "header", authHeader: false, authCookie: true, output: "unauthorised", setTokens: "none", clearedTokens: "none"},
+		{getTokenTransferMethodRes: "header", authHeader: false, authCookie: true, output: "unauthorised", setTokens: "none", clearedTokens: "both"},
 		{getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: true, output: "validatecookie", setTokens: "cookies", clearedTokens: "none"},
 		{getTokenTransferMethodRes: "any", authHeader: true, authCookie: false, output: "validateheader", setTokens: "headers", clearedTokens: "none"},
-		{getTokenTransferMethodRes: "header", authHeader: true, authCookie: false, output: "validateheader", setTokens: "headers", clearedTokens: "none"},
+		{getTokenTransferMethodRes: "header", authHeader: true, authCookie: false, output: "validateheader", setTokens: "headers", clearedTokens: "both"},
 		{getTokenTransferMethodRes: "cookie", authHeader: true, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none"},
 		{getTokenTransferMethodRes: "any", authHeader: true, authCookie: true, output: "validateheader", setTokens: "headers", clearedTokens: "cookies"},
 		{getTokenTransferMethodRes: "header", authHeader: true, authCookie: true, output: "validateheader", setTokens: "headers", clearedTokens: "cookies"},
@@ -1224,6 +1224,13 @@ func TestRefreshTokenBehaviour(t *testing.T) {
 				assert.Equal(t, refreshRes["accessTokenExpiry"], "Thu, 01 Jan 1970 00:00:00 GMT")
 				assert.Empty(t, refreshRes["sRefreshToken"])
 				assert.Equal(t, refreshRes["refreshTokenExpiry"], "Thu, 01 Jan 1970 00:00:00 GMT")
+			} else if behaviour.clearedTokens == "both" {
+				assert.Empty(t, refreshRes["accessTokenFromHeader"])
+				assert.Empty(t, refreshRes["refreshTokenFromHeader"])
+				assert.Empty(t, refreshRes["sAccessToken"])
+				assert.Equal(t, refreshRes["accessTokenExpiry"], "Thu, 01 Jan 1970 00:00:00 GMT")
+				assert.Empty(t, refreshRes["sRefreshToken"])
+				assert.Equal(t, refreshRes["refreshTokenExpiry"], "Thu, 01 Jan 1970 00:00:00 GMT")
 			}
 
 			switch behaviour.setTokens {
@@ -1247,17 +1254,18 @@ func TestRefreshTokenBehaviour(t *testing.T) {
 				}
 			}
 
-			if behaviour.setTokens != "cookies" && behaviour.clearedTokens != "cookies" {
-				assert.Equal(t, refreshRes["sAccessToken"], "-not-present-")
-				assert.Equal(t, refreshRes["accessTokenExpiry"], "-not-present-")
-				assert.Equal(t, refreshRes["sRefreshToken"], "-not-present-")
-				assert.Equal(t, refreshRes["refreshTokenExpiry"], "-not-present-")
+			if behaviour.setTokens != "both" {
+				if behaviour.setTokens != "cookies" && behaviour.clearedTokens != "cookies" {
+					assert.Equal(t, refreshRes["sAccessToken"], "-not-present-")
+					assert.Equal(t, refreshRes["accessTokenExpiry"], "-not-present-")
+					assert.Equal(t, refreshRes["sRefreshToken"], "-not-present-")
+					assert.Equal(t, refreshRes["refreshTokenExpiry"], "-not-present-")
+				}
+				if behaviour.setTokens != "headers" && behaviour.clearedTokens != "headers" {
+					assert.Equal(t, refreshRes["accessTokenFromHeader"], "-not-present-")
+					assert.Equal(t, refreshRes["refreshTokenFromHeader"], "-not-present-")
+				}
 			}
-			if behaviour.setTokens != "headers" && behaviour.clearedTokens != "headers" {
-				assert.Equal(t, refreshRes["accessTokenFromHeader"], "-not-present-")
-				assert.Equal(t, refreshRes["refreshTokenFromHeader"], "-not-present-")
-			}
-
 		})
 
 		t.Run(fmt.Sprintf("behaviour %v with invalid token", behaviour), func(t *testing.T) {

--- a/recipe/session/sessionRequestFunctions.go
+++ b/recipe/session/sessionRequestFunctions.go
@@ -386,7 +386,7 @@ func RefreshSessionInRequest(req *http.Request, res http.ResponseWriter, config 
 		False := false
 		return nil, errors.UnauthorizedError{
 			Msg:         "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
-			ClearTokens: &False,
+			ClearTokens: &True,
 		}
 	}
 
@@ -406,7 +406,7 @@ func RefreshSessionInRequest(req *http.Request, res http.ResponseWriter, config 
 
 		if ridFromHeader == nil {
 			supertokens.LogDebugMessage("refreshSession: Returning UNAUTHORISED because custom header (rid) was not passed")
-			clearTokens := false
+			clearTokens := true
 			return nil, errors.UnauthorizedError{
 				Msg:         "anti-csrf check failed. Please pass 'rid: \"session\"' header in the request.",
 				ClearTokens: &clearTokens,

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.22.0"
+const VERSION = "0.22.1"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

test: move the session object and claims to the BE sdk server

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

Updated existing tests

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 
