### PR TITLE
feat!: remove default maxAgeInSeconds in emailverification claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.23.0] - 2024-07-10
+
+### Breaking Changes
+
+-   Removes the default `maxAgeInSeconds` value (previously 300 seconds) in EmailVerification Claim. If the claim value is true and `maxAgeInSeconds` is not provided, it will not be refetched.
+
 ## [0.22.1] - 2024-07-09
 
 ### Changes

--- a/recipe/emailverification/emailverificationClaim_test.go
+++ b/recipe/emailverification/emailverificationClaim_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package emailverification
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/emailverification/evclaims"
+)
+
+func TestEmailVerificationClaim(t *testing.T) {
+	t.Run("value should be fetched if it is nil", func(t *testing.T) {
+		validator := evclaims.EmailVerificationClaimValidators.IsVerified(nil, nil)
+
+		shouldRefreshNil := validator.ShouldRefetch(nil, nil)
+
+		assert.True(t, shouldRefreshNil)
+	})
+
+	t.Run("value should be fetched as per maxAgeInSeconds if it is provided", func(t *testing.T) {
+		refetchTimeOnFalseInSeconds := int64(10)
+		maxAgeInSeconds := int64(200)
+		validator := evclaims.EmailVerificationClaimValidators.IsVerified(&refetchTimeOnFalseInSeconds, &maxAgeInSeconds)
+
+		payload := map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": true,
+				"t": time.Now().UnixMilli() - 199*1000,
+			},
+		}
+
+		shouldRefreshValid := validator.ShouldRefetch(payload, nil)
+
+		assert.False(t, shouldRefreshValid)
+
+		payload = map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": true,
+				"t": time.Now().UnixMilli() - 201*1000,
+			},
+		}
+
+		shouldRefreshExpired := validator.ShouldRefetch(payload, nil)
+		assert.True(t, shouldRefreshExpired)
+	})
+
+	t.Run("value should be fetched as per refetchTimeOnFalseInSeconds if it is provided", func(t *testing.T) {
+		refetchTimeOnFalseInSeconds := int64(8)
+		validator := evclaims.EmailVerificationClaimValidators.IsVerified(&refetchTimeOnFalseInSeconds, nil)
+
+		payload := map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": false,
+				"t": time.Now().UnixMilli() - 7*1000,
+			},
+		}
+
+		shouldRefreshValid := validator.ShouldRefetch(payload, nil)
+
+		assert.False(t, shouldRefreshValid)
+
+		payload = map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": false,
+				"t": time.Now().UnixMilli() - 9*1000,
+			},
+		}
+
+		shouldRefreshExpired := validator.ShouldRefetch(payload, nil)
+		assert.True(t, shouldRefreshExpired)
+	})
+
+	t.Run("value should be fetched as per default the refetchTimeOnFalseInSeconds if it is not provided", func(t *testing.T) {
+		validator := evclaims.EmailVerificationClaimValidators.IsVerified(nil, nil)
+
+		// NOTE: the default value of refetchTimeOnFalseInSeconds is 10 seconds
+		payload := map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": false,
+				"t": time.Now().UnixMilli() - 9*1000,
+			},
+		}
+
+		shouldRefreshValid := validator.ShouldRefetch(payload, nil)
+
+		assert.False(t, shouldRefreshValid)
+
+		payload = map[string]interface{}{
+			"st-ev": map[string]interface{}{
+				"v": false,
+				"t": time.Now().UnixMilli() - 11*1000,
+			},
+		}
+
+		shouldRefreshExpired := validator.ShouldRefetch(payload, nil)
+		assert.True(t, shouldRefreshExpired)
+	})
+}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.22.1"
+const VERSION = "0.23.0"
 
 var (
 	cdiSupported = []string{"3.0"}


### PR DESCRIPTION
## Summary of change

This PR removes the default `maxAgeInSeconds` value (previously 300 seconds) in EmailVerification Claim. If the claim value is true and `maxAgeInSeconds` is not provided, it will not be refetched.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 

