### PR TITLE
fix: Failing tests related to checking invalid input in formFields

### DIFF
--- a/recipe/emailpassword/formFieldValidator_test.go
+++ b/recipe/emailpassword/formFieldValidator_test.go
@@ -168,8 +168,8 @@ func TestInvalidAPIInputForFormFields(t *testing.T) {
 					},
 				},
 			},
-			expected:   "formFields must be an array of objects containing id and value of type string",
-			fieldError: false,
+			expected:   "Field is not optional",
+			fieldError: true,
 		},
 		{
 			input: map[string]interface{}{
@@ -179,8 +179,8 @@ func TestInvalidAPIInputForFormFields(t *testing.T) {
 					},
 				},
 			},
-			expected:   "formFields must be an array of objects containing id and value of type string",
-			fieldError: false,
+			expected:   "Field is not optional",
+			fieldError: true,
 		},
 		{
 			input: map[string]interface{}{


### PR DESCRIPTION
## Summary of change

This commit fixes a failing test case that was testing for an invalid input in formFields with non string value but since that type of value is now supported, the test case was broken.

## Test Plan

`TestInvalidAPIInputForFormFields` should pass.

![Screenshot 2024-09-24 at 7 45 08 PM](https://github.com/user-attachments/assets/0e0a6533-04f5-40f4-a044-737795b3a2d0)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 