### PR TITLE
fix: concurrent map writes error and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.25.0] - 2024-09-25
+
+### Changes
+
+- Removes use of `UserContext` in user GET API in dashboard recipe.
+
+### Breaking changes
+
+- Changes the type of `value` in `TypeFormField` to `interface{}` instead of `string`to add support for any type of value in form fields.
+
 ## [0.24.3] - 2024-09-24
 
 - Adds support for form field related improvements by making fields accept any type of values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Removes use of `UserContext` in user GET API in dashboard recipe.
+- Makes optional fields properly optional (i:e the value can be omitted entirely)
 
 ### Breaking changes
 
-- Changes the type of `value` in `TypeFormField` to `interface{}` instead of `string`to add support for any type of value in form fields.
-
-## [0.24.3] - 2024-09-24
-
-- Adds support for form field related improvements by making fields accept any type of values
-- Adds support for optional fields to properly optional
+- Changes the type of `value` in `TypeFormField` to `interface{}` instead of `string` to add support for any type of value in form fields.
 
 ## [0.24.2] - 2024-09-03
 

--- a/recipe/dashboard/api/usersGet.go
+++ b/recipe/dashboard/api/usersGet.go
@@ -121,6 +121,10 @@ func UsersGet(apiImplementation dashboardmodels.APIInterface, tenantId string, o
 			User     map[string]interface{} `json:"user"`
 		}) {
 			defer processingGroup.Done()
+
+			// NOTE: If userContext is passed in the following call, it could
+			// possibly lead to a concurrent map write error so it's important
+			// to be careful while adding that.
 			userMetadataResponse, err := usermetadata.GetUserMetadata(userObj.User["id"].(string))
 			<-sem
 			if err != nil {

--- a/recipe/dashboard/api/usersGet.go
+++ b/recipe/dashboard/api/usersGet.go
@@ -121,7 +121,7 @@ func UsersGet(apiImplementation dashboardmodels.APIInterface, tenantId string, o
 			User     map[string]interface{} `json:"user"`
 		}) {
 			defer processingGroup.Done()
-			userMetadataResponse, err := usermetadata.GetUserMetadata(userObj.User["id"].(string), userContext)
+			userMetadataResponse, err := usermetadata.GetUserMetadata(userObj.User["id"].(string))
 			<-sem
 			if err != nil {
 				errInBackground = err

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.24.3"
+const VERSION = "0.25.0"
 
 var (
 	cdiSupported = []string{"3.1"}


### PR DESCRIPTION
## Summary of change

- Fixes dashboard crashing on refresh (due to user GET API making the SDK crash)
- Bumps version to 0.25.0

## Test Plan

Example go app with dashboard recipe should not crash on refreshes.

### [Jam showing the main fix in action](https://jam.dev/c/19422340-12c6-4c24-a76a-075dbdc885eb)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 
