### PR TITLE
fix: Update changelog with migration guide for form field value consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changes the type of `value` in `TypeFormField` to `interface{}` instead of `string` to add support for any type of value in form fields.
 
+### Migration
+
+#### Typecast value of form fields to expected type before using it
+
+To read a value from formFields where id is `name`,
+
+Before:
+
+```go
+// formField should be of type []epmodels.TypeFormField
+var name string
+for id, value := range formFields {
+    if id == "name" {
+        name = value
+    }
+}
+```
+
+After:
+
+```go
+// formField should be of type []epmodels.TypeFormField
+var name string
+for id, value := ranger formFields {
+    if id == "name" {
+        nameAsStr, asStrOk := value.(string)
+        if !asStrOk {
+            // Handle the error accordingly
+        }
+        name = nameAsStr
+    }
+}
+```
+
 ## [0.24.2] - 2024-09-03
 
 - Fixes memory leak with the JWKS cache.


### PR DESCRIPTION
## Summary of change

This PR updates the changelog to add migration details for using `TypeFormField` value.

## Test Plan

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core 
