### PR TITLE
feat: normalise dashboard connection url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.25.1] - 2024-10-02
+
+- Adds support for normalizing the connection URI's before returning them in dashboard GET response.
+
 ## [0.25.0] - 2024-09-25
 
 ### Changes

--- a/recipe/dashboard/api/implementation.go
+++ b/recipe/dashboard/api/implementation.go
@@ -47,11 +47,18 @@ func MakeAPIImplementation() dashboardmodels.APIInterface {
 			return "", err
 		}
 
+		// We are splitting the passed URI here so that if multiple URI's are passed
+		// separated by a colon, the first one is returned.
 		connectionURIToNormalize := strings.Split(stInstance.SuperTokens.ConnectionURI, ";")[0]
 
+		// This normalizes the URI to make sure that it has things like protocol etc
+		// injected into it before it is returned.
 		var normalizationError error
 		normalizedConnectionURI, normalizationError := supertokens.NewNormalisedURLDomain(connectionURIToNormalize)
 		if normalizationError != nil {
+			// In case of failures, we want to return a 500 here, mainly because that
+			// is what we return if the connectionURI is invalid which is the case here
+			// if normalization fails.
 			return "", normalizationError
 		}
 		connectionURI := normalizedConnectionURI.GetAsStringDangerous()

--- a/recipe/dashboard/api/implementation.go
+++ b/recipe/dashboard/api/implementation.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/supertokens/supertokens-golang/recipe/dashboard/constants"
 	"github.com/supertokens/supertokens-golang/recipe/dashboard/dashboardmodels"
@@ -45,7 +46,15 @@ func MakeAPIImplementation() dashboardmodels.APIInterface {
 		if err != nil {
 			return "", err
 		}
-		connectionURI := stInstance.SuperTokens.ConnectionURI
+
+		connectionURIToNormalize := strings.Split(stInstance.SuperTokens.ConnectionURI, ";")[0]
+
+		var normalizationError error
+		normalizedConnectionURI, normalizationError := supertokens.NewNormalisedURLDomain(connectionURIToNormalize)
+		if normalizationError != nil {
+			return "", normalizationError
+		}
+		connectionURI := normalizedConnectionURI.GetAsStringDangerous()
 
 		normalizedDashboardPath, err := supertokens.NewNormalisedURLPath(constants.DashboardAPI)
 		if err != nil {

--- a/recipe/dashboard/dashboardGet_test.go
+++ b/recipe/dashboard/dashboardGet_test.go
@@ -1,0 +1,162 @@
+package dashboard
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supertokens/supertokens-golang/recipe/emailpassword"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/supertokens/supertokens-golang/recipe/dashboard/dashboardmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+	"github.com/supertokens/supertokens-golang/test/unittesting"
+)
+
+func TestThatDashboardGetNormalizesConnectionURIWithoutHTTP(t *testing.T) {
+	connectionURI := "http://localhost:8080"
+	connectionURIWithoutProtocol := strings.Replace(connectionURI, "http://", "", -1)
+	config := supertokens.TypeInput{
+		OnSuperTokensAPIError: func(err error, req *http.Request, res http.ResponseWriter) {
+			print(err)
+		},
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: connectionURIWithoutProtocol,
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			emailpassword.Init(nil),
+			Init(&dashboardmodels.TypeInput{
+				ApiKey: "testapikey",
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(config)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	req, err := http.NewRequest(http.MethodGet, testServer.URL+"/auth/dashboard", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer testapikey")
+	res, err := http.DefaultClient.Do(req)
+	assert.Equal(t, res.StatusCode, 200)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	body, _ := io.ReadAll(res.Body)
+	assert.True(t, strings.Contains(string(body), fmt.Sprintf("window.connectionURI = \"%s\"", connectionURI)))
+}
+
+func TestThatDashboardGetNormalizesConnectionURIWithoutHTTPS(t *testing.T) {
+	connectionURI := "https://try.supertokens.com"
+	connectionURIWithoutProtocol := strings.Replace(connectionURI, "https://", "", -1)
+	config := supertokens.TypeInput{
+		OnSuperTokensAPIError: func(err error, req *http.Request, res http.ResponseWriter) {
+			print(err)
+		},
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: connectionURIWithoutProtocol,
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			emailpassword.Init(nil),
+			Init(&dashboardmodels.TypeInput{
+				ApiKey: "testapikey",
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(config)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	req, err := http.NewRequest(http.MethodGet, testServer.URL+"/auth/dashboard", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer testapikey")
+	res, err := http.DefaultClient.Do(req)
+	assert.Equal(t, res.StatusCode, 200)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	body, _ := io.ReadAll(res.Body)
+	assert.True(t, strings.Contains(string(body), fmt.Sprintf("window.connectionURI = \"%s\"", connectionURI)))
+}
+
+func TestThatDashboardGetReturnsFirstURIWhenMultipleArePassed(t *testing.T) {
+	firstConnectionURI := "http://localhost:8080"
+	secondConnectionURI := "https://try.supertokens.com"
+	multiplConnectionURIs := fmt.Sprintf("%s;%s", firstConnectionURI, secondConnectionURI)
+	config := supertokens.TypeInput{
+		OnSuperTokensAPIError: func(err error, req *http.Request, res http.ResponseWriter) {
+			print(err)
+		},
+		Supertokens: &supertokens.ConnectionInfo{
+			ConnectionURI: multiplConnectionURIs,
+		},
+		AppInfo: supertokens.AppInfo{
+			APIDomain:     "api.supertokens.io",
+			AppName:       "SuperTokens",
+			WebsiteDomain: "supertokens.io",
+		},
+		RecipeList: []supertokens.Recipe{
+			emailpassword.Init(nil),
+			Init(&dashboardmodels.TypeInput{
+				ApiKey: "testapikey",
+			}),
+		},
+	}
+
+	BeforeEach()
+	unittesting.StartUpST("localhost", "8080")
+	defer AfterEach()
+	err := supertokens.Init(config)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	mux := http.NewServeMux()
+	testServer := httptest.NewServer(supertokens.Middleware(mux))
+	defer testServer.Close()
+
+	req, err := http.NewRequest(http.MethodGet, testServer.URL+"/auth/dashboard", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer testapikey")
+	res, err := http.DefaultClient.Do(req)
+	assert.Equal(t, res.StatusCode, 200)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	body, _ := io.ReadAll(res.Body)
+	assert.True(t, strings.Contains(string(body), fmt.Sprintf("window.connectionURI = \"%s\"", firstConnectionURI)))
+}

--- a/supertokens/constants.go
+++ b/supertokens/constants.go
@@ -21,7 +21,7 @@ const (
 )
 
 // VERSION current version of the lib
-const VERSION = "0.25.0"
+const VERSION = "0.25.1"
 
 var (
 	cdiSupported = []string{"3.1"}


### PR DESCRIPTION
## Summary of change

This PR adds support for normalizing connection URI before returning them in dashboard GET.

Copy of https://github.com/supertokens/supertokens-node/pull/760 from the node SDK.

## Related issues

- https://github.com/supertokens/supertokens-node/pull/760

## Test Plan

- dashboardGet_test.go should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `supertokens/constants.go`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `supertokens/constants.go > version variable`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/config_utils.go` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If access token structure has changed
    -   Modified test in `session/accessTokenVersions_test.go` to account for any new claims that are optional or omitted by the core
 