### PR TITLE
feat(passwordless): return code lifetime in CreateMagicLink helper functions

### DIFF
--- a/recipe/passwordless/main.go
+++ b/recipe/passwordless/main.go
@@ -208,10 +208,10 @@ func ListCodesByPreAuthSessionID(tenantId string, preAuthSessionID string, userC
 	return (*instance.RecipeImpl.ListCodesByPreAuthSessionID)(preAuthSessionID, tenantId, userContext[0])
 }
 
-func CreateMagicLinkByEmail(tenantId string, email string, userContext ...supertokens.UserContext) (string, error) {
+func CreateMagicLinkByEmail(tenantId string, email string, userContext ...supertokens.UserContext) (string, uint64, error) {
 	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if len(userContext) == 0 {
 		userContext = append(userContext, &map[string]interface{}{})
@@ -219,10 +219,10 @@ func CreateMagicLinkByEmail(tenantId string, email string, userContext ...supert
 	return instance.CreateMagicLink(&email, nil, tenantId, userContext[0])
 }
 
-func CreateMagicLinkByPhoneNumber(tenantId string, phoneNumber string, userContext ...supertokens.UserContext) (string, error) {
+func CreateMagicLinkByPhoneNumber(tenantId string, phoneNumber string, userContext ...supertokens.UserContext) (string, uint64, error) {
 	instance, err := GetRecipeInstanceOrThrowError()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if len(userContext) == 0 {
 		userContext = append(userContext, &map[string]interface{}{})

--- a/recipe/passwordless/recipe.go
+++ b/recipe/passwordless/recipe.go
@@ -232,23 +232,23 @@ func (r *Recipe) handleError(err error, req *http.Request, res http.ResponseWrit
 	return false, nil
 }
 
-func (r *Recipe) CreateMagicLink(email *string, phoneNumber *string, tenantId string, userContext supertokens.UserContext) (string, error) {
+func (r *Recipe) CreateMagicLink(email *string, phoneNumber *string, tenantId string, userContext supertokens.UserContext) (string, uint64, error) {
 	stInstance, err := supertokens.GetInstanceOrThrowError()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	var userInputCodeInput *string
 	if r.Config.GetCustomUserInputCode != nil {
 		c, err := r.Config.GetCustomUserInputCode(tenantId, userContext)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		userInputCodeInput = &c
 	}
 
 	response, err := (*r.RecipeImpl.CreateCode)(email, phoneNumber, userInputCodeInput, tenantId, userContext)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	link, err := api.GetMagicLink(
 		stInstance.AppInfo,
@@ -259,7 +259,7 @@ func (r *Recipe) CreateMagicLink(email *string, phoneNumber *string, tenantId st
 		userContext,
 	)
 
-	return link, err
+	return link, response.OK.CodeLifetime, err
 }
 
 func (r *Recipe) SignInUp(email *string, phoneNumber *string, tenantId string, userContext supertokens.UserContext) (struct {

--- a/recipe/passwordless/recipeFucntions_test.go
+++ b/recipe/passwordless/recipeFucntions_test.go
@@ -1034,8 +1034,9 @@ func TestCreatingMagicLink(t *testing.T) {
 		return
 	}
 
-	link, err := CreateMagicLinkByPhoneNumber("public", "+1234567890")
+	link, codeLifetime, err := CreateMagicLinkByPhoneNumber("public", "+1234567890")
 	assert.NoError(t, err)
+	assert.True(t, codeLifetime > 0)
 
 	res, err := url.Parse(link)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
Fixes #428.

When calling \CreateMagicLink\, \CreateMagicLinkByEmail\, or \CreateMagicLinkByPhoneNumber\, the underlying \CreateCode\ response includes \CodeLifetime\ (uint64) indicating how long the generated magic link code remains valid. Previously, this lifetime was discarded and only the URL string was returned, requiring callers to hardcode or guess the link's expiration duration when rendering custom notification/email templates.

This PR updates \CreateMagicLink\, \CreateMagicLinkByEmail\, and \CreateMagicLinkByPhoneNumber\ to return \(string, uint64, error)\ so callers receive the exact \CodeLifetime\ along with the magic link URL.

## Changes
- \ecipe/passwordless/recipe.go\: Updated \CreateMagicLink\ return signature to \(string, uint64, error)\ and return \esponse.OK.CodeLifetime\.
- \ecipe/passwordless/main.go\: Updated \CreateMagicLinkByEmail\ and \CreateMagicLinkByPhoneNumber\ return signatures to \(string, uint64, error)\.
- \ecipe/passwordless/recipeFucntions_test.go\: Updated test assertion in \TestCreatingMagicLink\.